### PR TITLE
EXP: support output of details of gather

### DIFF
--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -96,6 +96,13 @@ pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     }
 
     // run the gather!
-    consume_query_by_gather(query, matchlist, threshold_hashes, gather_output, details_output).ok();
+    consume_query_by_gather(
+        query,
+        matchlist,
+        threshold_hashes,
+        gather_output,
+        details_output,
+    )
+    .ok();
     Ok(())
 }

--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -19,6 +19,7 @@ pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     template: Sketch,
     gather_output: Option<P>,
     prefetch_output: Option<P>,
+    details_output: Option<P>,
 ) -> Result<()> {
     let location = query_filename.to_string();
     eprintln!("Loading query from '{}'", location);
@@ -95,6 +96,6 @@ pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     }
 
     // run the gather!
-    consume_query_by_gather(query, matchlist, threshold_hashes, gather_output).ok();
+    consume_query_by_gather(query, matchlist, threshold_hashes, gather_output, details_output).ok();
     Ok(())
 }

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -112,7 +112,7 @@ pub fn fastmultigather<P: AsRef<Path> + std::fmt::Debug + Clone>(
                 write_prefetch(&query, Some(prefetch_output), &matchlist).ok();
 
                 // now, do the gather!
-                consume_query_by_gather(query, matchlist, threshold_hashes, Some(gather_output))
+                consume_query_by_gather(query, matchlist, threshold_hashes, Some(gather_output), None)
                     .ok();
             } else {
                 println!("No matches to '{}'", location);

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -112,8 +112,14 @@ pub fn fastmultigather<P: AsRef<Path> + std::fmt::Debug + Clone>(
                 write_prefetch(&query, Some(prefetch_output), &matchlist).ok();
 
                 // now, do the gather!
-                consume_query_by_gather(query, matchlist, threshold_hashes, Some(gather_output), None)
-                    .ok();
+                consume_query_by_gather(
+                    query,
+                    matchlist,
+                    threshold_hashes,
+                    Some(gather_output),
+                    None,
+                )
+                .ok();
             } else {
                 println!("No matches to '{}'", location);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ fn do_fastgather(
     moltype: String,
     output_path_prefetch: Option<String>,
     output_path_gather: Option<String>,
+    output_path_details: Option<String>,
 ) -> anyhow::Result<u8> {
     let template = build_template(ksize, scaled, &moltype);
     match fastgather::fastgather(
@@ -81,6 +82,7 @@ fn do_fastgather(
         template,
         output_path_prefetch,
         output_path_gather,
+        output_path_details,
     ) {
         Ok(_) => Ok(0),
         Err(e) => {

--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -103,6 +103,7 @@ class Branchwater_Fastgather(CommandLinePlugin):
                        help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
         p.add_argument('-c', '--cores', default=0, type=int,
                 help='number of cores to use (default is all available)')
+        p.add_argument('--output-details')
 
 
     def main(self, args):
@@ -122,7 +123,8 @@ class Branchwater_Fastgather(CommandLinePlugin):
                                                            args.scaled,
                                                            args.moltype,
                                                            args.output_gather,
-                                                           args.output_prefetch)
+                                                           args.output_prefetch,
+                                                           args.output_details)
         if status == 0:
             notify(f"...fastgather is done! gather results in '{args.output_gather}'")
             if args.output_prefetch:

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -717,7 +717,7 @@ pub fn consume_query_by_gather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Disp
     matchlist: BinaryHeap<PrefetchResult>,
     threshold_hashes: u64,
     gather_output: Option<P>,
-    details_output: Option<P>
+    details_output: Option<P>,
 ) -> Result<()> {
     // Set up a writer for gather output
     let gather_out: Box<dyn Write> = match gather_output {
@@ -739,8 +739,9 @@ pub fn consume_query_by_gather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Disp
     writeln!(
         &mut details_writer,
         "rank,query_size,remaining_hashes,sub_hashes,remaining_sketches,sub_matches"
-    ).ok();
-    
+    )
+    .ok();
+
     let mut matching_sketches = matchlist;
     let mut rank = 0;
 
@@ -803,8 +804,9 @@ pub fn consume_query_by_gather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Disp
             sub_hashes,
             matching_sketches.len(),
             sub_matches
-        ).ok();
-            
+        )
+        .ok();
+
         last_hashes = query_mh.size();
         last_matches = matching_sketches.len();
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -738,7 +738,7 @@ pub fn consume_query_by_gather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Disp
     let mut details_writer = BufWriter::new(details_out);
     writeln!(
         &mut details_writer,
-        "rank,query_size,remaining_hashes,sub_hashes,remaining_sketches,sub_matches"
+        "rank,remaining_hashes,sub_hashes,remaining_sketches,sub_matches"
     )
     .ok();
 


### PR DESCRIPTION
This adds CSV output containing the number of matches and the number of hashes remaining at each stage of fastgather.
