### PR TITLE
MRG: Add the `pairwise` subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ fastmultigather = "sourmash_plugin_branchwater:Branchwater_Fastmultigather"
 index = "sourmash_plugin_branchwater:Branchwater_Index"
 check = "sourmash_plugin_branchwater:Branchwater_Check"
 manysketch = "sourmash_plugin_branchwater:Branchwater_Manysketch"
+pairwise = "sourmash_plugin_branchwater:Branchwater_Pairwise"
 
 [project.optional-dependencies]
 test = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,12 +219,7 @@ fn do_pairwise(
     output_path: Option<String>,
 ) -> anyhow::Result<u8> {
     let template = build_template(ksize, scaled, &moltype);
-    match pairwise::pairwise(
-        siglist_path,
-        threshold,
-        template,
-        output_path,
-    ) {
+    match pairwise::pairwise(siglist_path, threshold, template, output_path) {
         Ok(_) => Ok(0),
         Err(e) => {
             eprintln!("Error: {e}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod manysketch;
 mod mastiff_manygather;
 mod mastiff_manysearch;
 mod multisearch;
+mod pairwise;
 
 #[pyfunction]
 fn do_manysearch(
@@ -209,6 +210,30 @@ fn do_multisearch(
 }
 
 #[pyfunction]
+fn do_pairwise(
+    siglist_path: String,
+    threshold: f64,
+    ksize: u8,
+    scaled: usize,
+    moltype: String,
+    output_path: Option<String>,
+) -> anyhow::Result<u8> {
+    let template = build_template(ksize, scaled, &moltype);
+    match pairwise::pairwise(
+        siglist_path,
+        threshold,
+        template,
+        output_path,
+    ) {
+        Ok(_) => Ok(0),
+        Err(e) => {
+            eprintln!("Error: {e}");
+            Ok(1)
+        }
+    }
+}
+
+#[pyfunction]
 fn do_manysketch(filelist: String, param_str: String, output: String) -> anyhow::Result<u8> {
     match manysketch::manysketch(filelist, param_str, output) {
         Ok(_) => Ok(0),
@@ -229,5 +254,6 @@ fn sourmash_plugin_branchwater(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_manysketch, m)?)?;
     m.add_function(wrap_pyfunction!(set_global_thread_pool, m)?)?;
     m.add_function(wrap_pyfunction!(do_multisearch, m)?)?;
+    m.add_function(wrap_pyfunction!(do_pairwise, m)?)?;
     Ok(())
 }

--- a/src/pairwise.rs
+++ b/src/pairwise.rs
@@ -78,7 +78,8 @@ pub fn pairwise<P: AsRef<Path>>(
                     max_containment,
                     jaccard,
                     overlap,
-                )).unwrap();
+                ))
+                .unwrap();
             }
 
             let i = processed_cmp.fetch_add(1, atomic::Ordering::SeqCst);

--- a/src/pairwise.rs
+++ b/src/pairwise.rs
@@ -1,0 +1,103 @@
+use anyhow::Result;
+/// pairwise: massively parallel in-memory sketch search.
+use rayon::prelude::*;
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use std::sync::atomic;
+use std::sync::atomic::AtomicUsize;
+
+use sourmash::signature::SigsTrait;
+use sourmash::sketch::Sketch;
+
+use crate::utils::{load_sketches_from_zip_or_pathlist, ReportType};
+
+/// Search many queries against a list of signatures.
+///
+/// Note: this function loads all _queries_ into memory, and iterates over
+/// database once.
+
+pub fn pairwise<P: AsRef<Path>>(
+    siglist: P,
+    threshold: f64,
+    template: Sketch,
+    output: Option<P>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Load all queries into memory at once.
+    let queries = load_sketches_from_zip_or_pathlist(&siglist, &template, ReportType::Query)?;
+
+    // set up a multi-producer, single-consumer channel.
+    let (send, recv) = std::sync::mpsc::sync_channel(rayon::current_num_threads());
+
+    // & spawn a thread that is dedicated to printing to a buffered output
+    let out: Box<dyn Write + Send> = match output {
+        Some(path) => Box::new(BufWriter::new(File::create(path).unwrap())),
+        None => Box::new(std::io::stdout()),
+    };
+    let thrd = std::thread::spawn(move || {
+        let mut writer = BufWriter::new(out);
+        writeln!(&mut writer, "query_name,query_md5,match_name,match_md5,containment,max_containment,jaccard,intersect_hashes").unwrap();
+        for (query, query_md5, m, m_md5, cont, max_cont, jaccard, overlap) in recv.into_iter() {
+            writeln!(
+                &mut writer,
+                "\"{}\",{},\"{}\",{},{},{},{},{}",
+                query, query_md5, m, m_md5, cont, max_cont, jaccard, overlap
+            )
+            .ok();
+        }
+    });
+
+    //
+    // Main loop: iterate (in parallel) over all pairs of search signature paths,
+    // loading them individually and comparing them. Stuff results into
+    // the writer thread above.
+    //
+
+    let processed_cmp = AtomicUsize::new(0);
+
+    queries.par_iter().enumerate().for_each(|(i, q1)| {
+        for q2 in &queries[(i + 1)..] {
+            let overlap = q1.minhash.count_common(&q2.minhash, false).unwrap() as f64;
+            let query1_size = q1.minhash.size() as f64;
+            let query2_size = q2.minhash.size() as f64;
+
+            let containment_q1_in_q2 = overlap / query1_size;
+            let containment_q2_in_q1 = overlap / query2_size;
+            let max_containment = containment_q1_in_q2.max(containment_q2_in_q1);
+            let jaccard = overlap / (query1_size + query2_size - overlap);
+
+            if containment_q1_in_q2 > threshold || containment_q2_in_q1 > threshold {
+                send.send((
+                    q1.name.clone(),
+                    q1.md5sum.clone(),
+                    q2.name.clone(),
+                    q2.md5sum.clone(),
+                    containment_q1_in_q2,
+                    max_containment,
+                    jaccard,
+                    overlap,
+                )).unwrap();
+            }
+
+            let i = processed_cmp.fetch_add(1, atomic::Ordering::SeqCst);
+            if i % 100000 == 0 {
+                eprintln!("Processed {} comparisons", i);
+            }
+        }
+    });
+
+    // do some cleanup and error handling -
+    drop(send); // close the channel
+
+    if let Err(e) = thrd.join() {
+        eprintln!("Unable to join internal thread: {:?}", e);
+    }
+
+    // done!
+    let i: usize = processed_cmp.load(atomic::Ordering::SeqCst);
+    eprintln!("DONE. Processed {} comparisons", i);
+
+    Ok(())
+}

--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -276,6 +276,47 @@ class Branchwater_Multisearch(CommandLinePlugin):
         if status == 0:
             notify(f"...multisearch is done! results in '{args.output}'")
         return status
+    
+class Branchwater_Pairwise(CommandLinePlugin):
+    command = 'pairwise'
+    description = 'massively parallel in-memory pairwise comparisons'
+
+    def __init__(self, p):
+        super().__init__(p)
+        p.add_argument('sig_paths',
+                       help="a text file containing paths to .sig/.sig.gz files")
+        p.add_argument('-o', '--output', required=True,
+                       help='CSV output file for matches')
+        p.add_argument('-t', '--threshold', default=0.01, type=float,
+                       help='containment threshold for reporting matches')
+        p.add_argument('-k', '--ksize', default=31, type=int,
+                       help='k-mer size at which to select sketches')
+        p.add_argument('-s', '--scaled', default=1000, type=int,
+                       help='scaled factor at which to do comparisons')
+        p.add_argument('-m', '--moltype', default='DNA', choices = ["DNA", "protein", "dayhoff", "hp"],
+                       help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
+        p.add_argument('-c', '--cores', default=0, type=int,
+                       help='number of cores to use (default is all available)')
+
+    def main(self, args):
+        print_version()
+        notify(f"ksize: {args.ksize} / scaled: {args.scaled} / moltype: {args.moltype} / threshold: {args.threshold}")
+        args.moltype = args.moltype.lower()
+
+        num_threads = set_thread_pool(args.cores)
+
+        notify(f"pairwise-comparing all sketches in '{args.sig_paths}' using {num_threads} threads")
+
+        super().main(args)
+        status = sourmash_plugin_branchwater.do_pairwise(args.sig_paths,
+                                                            args.threshold,
+                                                            args.ksize,
+                                                            args.scaled,
+                                                            args.moltype,
+                                                            args.output)
+        if status == 0:
+            notify(f"...pairwise is done! results in '{args.output}'")
+        return status
 
 
 class Branchwater_Manysketch(CommandLinePlugin):

--- a/src/python/tests/test_pairwise.py
+++ b/src/python/tests/test_pairwise.py
@@ -1,0 +1,483 @@
+import os
+import pytest
+import pandas
+import sourmash
+
+from . import sourmash_tst_utils as utils
+
+
+def get_test_data(filename):
+    thisdir = os.path.dirname(__file__)
+    return os.path.join(thisdir, 'test-data', filename)
+
+
+def make_file_list(filename, paths):
+    with open(filename, 'wt') as fp:
+        fp.write("\n".join(paths))
+        fp.write("\n")
+
+
+def test_installed(runtmp):
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'pairwise')
+
+    assert 'usage:  pairwise' in runtmp.last_result.err
+
+def zip_siglist(runtmp, siglist, db):
+    runtmp.sourmash('sig', 'cat', siglist,
+                    '-o', db)
+    return db
+
+@pytest.mark.parametrize("zip_query", [False, True])
+def test_simple(runtmp, zip_query):
+    # test basic execution!
+    query_list = runtmp.output('query.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(query_list, [sig2, sig47, sig63])
+
+    output = runtmp.output('out.csv')
+
+    if zip_query:
+        query_list = zip_siglist(runtmp, query_list, runtmp.output('query.zip'))
+
+    runtmp.sourmash('scripts', 'pairwise', query_list,
+                    '-o', output, '-t', '-1')
+    assert os.path.exists(output)
+
+    df = pandas.read_csv(output)
+    assert len(df) == 3
+
+    dd = df.to_dict(orient='index')
+    print(dd)
+
+    for idx, row in dd.items():
+        # identical?
+        if row['match_name'] == row['query_name']:
+            assert row['query_md5'] == row['match_md5'], row
+            assert float(row['containment'] == 1.0)
+            assert float(row['jaccard'] == 1.0)
+            assert float(row['max_containment'] == 1.0)
+
+        else:
+            # confirm hand-checked numbers
+            q = row['query_name'].split()[0]
+            m = row['match_name'].split()[0]
+            cont = float(row['containment'])
+            jaccard = float(row['jaccard'])
+            maxcont = float(row['max_containment'])
+            intersect_hashes = int(row['intersect_hashes'])
+
+            jaccard = round(jaccard, 4)
+            cont = round(cont, 4)
+            maxcont = round(maxcont, 4)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}")
+
+            if q == 'NC_011665.1' and m == 'NC_009661.1':
+                assert jaccard == 0.3207
+                assert cont == 0.4828
+                assert maxcont == 0.4885
+                assert intersect_hashes == 2529
+
+            if q == 'NC_009661.1' and m == 'NC_011665.1':
+                assert jaccard == 0.3207
+                assert cont == 0.4885
+                assert maxcont == 0.4885
+                assert intersect_hashes == 2529
+
+
+@pytest.mark.parametrize("zip_query", [False, True])
+def test_simple_threshold(runtmp, zip_query):
+    # test with a simple threshold => only 3 results
+    query_list = runtmp.output('query.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(query_list, [sig2, sig47, sig63])
+
+    output = runtmp.output('out.csv')
+
+
+    if zip_query:
+        query_list = zip_siglist(runtmp, query_list, runtmp.output('query.zip'))
+
+    runtmp.sourmash('scripts', 'pairwise', query_list,
+                    '-o', output, '-t', '0.1')
+    assert os.path.exists(output)
+
+    df = pandas.read_csv(output)
+    assert len(df) == 1
+
+
+
+def test_bad_query(runtmp, capfd):
+    # test with a bad query (a .sig.gz file)
+    against_list = runtmp.output('against.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(against_list, [sig2, sig47, sig63])
+
+    output = runtmp.output('out.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'pairwise', sig2,
+                        '-o', output)
+
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert 'Error: invalid line in fromfile ' in captured.err
+
+
+def test_bad_query_2(runtmp, capfd):
+    # test with a bad query list (a missing file)
+    query_list = runtmp.output('query.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+    make_file_list(query_list, [sig2, "no-exist"])
+
+    output = runtmp.output('out.csv')
+
+    runtmp.sourmash('scripts', 'pairwise', query_list,
+                    '-o', output)
+
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert "WARNING: could not load sketches from path 'no-exist'" in captured.err
+    assert "WARNING: 1 query paths failed to load. See error messages above." in captured.err
+
+
+
+
+def test_bad_query_3(runtmp, capfd):
+    # test with a bad query (a .sig.gz file renamed as zip file)
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    query_zip = runtmp.output('query.zip')
+    # cp sig2 into query_zip
+    with open(query_zip, 'wb') as fp:
+        with open(sig2, 'rb') as fp2:
+            fp.write(fp2.read())
+
+    output = runtmp.output('out.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'pairwise', query_zip,
+                        '-o', output)
+
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert 'Error: invalid Zip archive: Could not find central directory end' in captured.err
+
+
+@pytest.mark.parametrize("zip_db", [False, True])
+def test_missing_query(runtmp, capfd, zip_db):
+    # test with a missing query list
+    query_list = runtmp.output('query.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    output = runtmp.output('out.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'pairwise', query_list,
+                        '-o', output)
+        
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert 'Error: No such file or directory ' in captured.err
+
+
+
+def test_empty_query(runtmp):
+    # test with an empty query list
+    query_list = runtmp.output('query.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(query_list, [])
+
+    output = runtmp.output('out.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'pairwise', query_list,
+                        '-o', output)
+
+    print(runtmp.last_result.err)
+    # @CTB
+
+
+@pytest.mark.parametrize("zip_query", [False, True])
+def test_nomatch_query(runtmp, capfd, zip_query):
+    # test a non-matching (diff ksize) in query; do we get warning message?
+    query_list = runtmp.output('query.txt')
+
+    sig1 = get_test_data('1.fa.k21.sig.gz')
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(query_list, [sig2, sig47, sig63, sig1])
+
+    output = runtmp.output('out.csv')
+
+    if zip_query:
+        query_list = zip_siglist(runtmp, query_list, runtmp.output('query.zip'))
+
+    runtmp.sourmash('scripts', 'pairwise', query_list,
+                    '-o', output)
+    assert os.path.exists(output)
+
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert 'WARNING: skipped 1 query paths - no compatible signatures' in captured.err
+
+
+@pytest.mark.parametrize("zip_db", [False, True])
+def test_load_only_one_bug(runtmp, capfd, zip_db):
+    # check that we behave properly when presented with multiple query
+    # sketches
+    query_list = runtmp.output('query.txt')
+
+    sig1_k31 = get_test_data('1.fa.k31.sig.gz')
+
+    # note: this was created as a 3-sketch-in-one-signature directly
+    # via sourmash sketch dna -p k=21,k=31,k=51.
+    sig1_all = get_test_data('1.combined.sig.gz')
+
+    make_file_list(query_list, [sig1_all, sig1_k31])
+
+    if zip_db:
+        query_list = zip_siglist(runtmp, query_list, runtmp.output('db.zip'))
+
+    output = runtmp.output('out.csv')
+
+    runtmp.sourmash('scripts', 'pairwise', query_list,
+                    '-o', output)
+    assert os.path.exists(output)
+
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert not 'WARNING: skipped 1 paths - no compatible signatures.' in captured.err
+    assert not 'WARNING: no compatible sketches in path ' in captured.err
+
+
+
+
+
+
+
+@pytest.mark.parametrize("zip_query", [False, True])
+def test_md5(runtmp, zip_query):
+    # test that md5s match what was in the original files, not downsampled etc.
+    query_list = runtmp.output('query.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(query_list, [sig2, sig47, sig63])
+
+    output = runtmp.output('out.csv')
+
+    if zip_query:
+        query_list = zip_siglist(runtmp, query_list, runtmp.output('query.zip'))
+
+
+    runtmp.sourmash('scripts', 'pairwise', query_list,
+                    '-o', output, "-t", "-0.1")
+    assert os.path.exists(output)
+
+    df = pandas.read_csv(output)
+    assert len(df) == 3
+
+    md5s = list(df['query_md5']) + list(df['match_md5'])
+    print(f"md5s: {md5s}")
+
+    for query_file in (sig2, sig47, sig63):
+        for ss in sourmash.load_file_as_signatures(query_file, ksize=31):
+            assert ss.md5sum() in md5s
+
+    md5s = list(df['match_md5'])
+    print(md5s)
+
+
+
+
+def test_simple_prot(runtmp):
+    # test basic execution with protein sigs
+    sigs = get_test_data('protein.zip')
+
+    output = runtmp.output('out.csv')
+
+    runtmp.sourmash('scripts', 'pairwise', sigs,
+                    '-o', output, '--moltype', 'protein',
+                    '-k', '19', '--scaled', '100')
+    assert os.path.exists(output)
+
+    df = pandas.read_csv(output)
+    assert len(df) == 1
+
+    dd = df.to_dict(orient='index')
+    print(dd)
+
+    for idx, row in dd.items():
+        # identical?
+        if row['match_name'] == row['query_name']:
+            assert row['query_md5'] == row['match_md5'], row
+            assert float(row['containment'] == 1.0)
+            assert float(row['jaccard'] == 1.0)
+            assert float(row['max_containment'] == 1.0)
+
+        else:
+            # confirm hand-checked numbers
+            q = row['query_name'].split()[0]
+            m = row['match_name'].split()[0]
+            cont = float(row['containment'])
+            jaccard = float(row['jaccard'])
+            maxcont = float(row['max_containment'])
+            intersect_hashes = int(row['intersect_hashes'])
+
+            jaccard = round(jaccard, 4)
+            cont = round(cont, 4)
+            maxcont = round(maxcont, 4)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
+
+            if q == 'GCA_001593925' and m == 'GCA_001593935':
+                assert jaccard == 0.0434
+                assert cont == 0.1003
+                assert maxcont == 0.1003
+                assert intersect_hashes == 342
+
+            if q == 'GCA_001593935' and m == 'GCA_001593925':
+                assert jaccard == 0.0434
+                assert cont == 0.0712
+                assert maxcont == 0.1003
+                assert intersect_hashes == 342
+
+
+
+def test_simple_dayhoff(runtmp):
+    # test basic execution with dayhoff sigs
+    sigs = get_test_data('dayhoff.zip')
+
+    output = runtmp.output('out.csv')
+
+    runtmp.sourmash('scripts', 'pairwise', sigs,
+                    '-o', output, '--moltype', 'dayhoff',
+                    '-k', '19', '--scaled', '100')
+    assert os.path.exists(output)
+
+    df = pandas.read_csv(output)
+    assert len(df) == 1
+
+    dd = df.to_dict(orient='index')
+    print(dd)
+
+    for idx, row in dd.items():
+        # identical?
+        if row['match_name'] == row['query_name']:
+            assert row['query_md5'] == row['match_md5'], row
+            assert float(row['containment'] == 1.0)
+            assert float(row['jaccard'] == 1.0)
+            assert float(row['max_containment'] == 1.0)
+
+        else:
+            # confirm hand-checked numbers
+            q = row['query_name'].split()[0]
+            m = row['match_name'].split()[0]
+            cont = float(row['containment'])
+            jaccard = float(row['jaccard'])
+            maxcont = float(row['max_containment'])
+            intersect_hashes = int(row['intersect_hashes'])
+
+            jaccard = round(jaccard, 4)
+            cont = round(cont, 4)
+            maxcont = round(maxcont, 4)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
+
+            if q == 'GCA_001593925' and m == 'GCA_001593935':
+                assert jaccard == 0.1326
+                assert cont == 0.2815
+                assert maxcont == 0.2815
+                assert intersect_hashes == 930
+
+            if q == 'GCA_001593935' and m == 'GCA_001593925':
+                assert jaccard == 0.1326
+                assert cont == 0.2004
+                assert maxcont == 0.2815
+                assert intersect_hashes == 930
+
+
+def test_simple_hp(runtmp):
+    # test basic execution with hp sigs
+    sigs = get_test_data('hp.zip')
+
+    output = runtmp.output('out.csv')
+
+    runtmp.sourmash('scripts', 'pairwise', sigs,
+                    '-o', output, '--moltype', 'hp',
+                    '-k', '19', '--scaled', '100')
+    assert os.path.exists(output)
+
+    df = pandas.read_csv(output)
+    assert len(df) == 1
+
+    dd = df.to_dict(orient='index')
+    print(dd)
+
+    for idx, row in dd.items():
+        # identical?
+        if row['match_name'] == row['query_name']:
+            assert row['query_md5'] == row['match_md5'], row
+            assert float(row['containment'] == 1.0)
+            assert float(row['jaccard'] == 1.0)
+            assert float(row['max_containment'] == 1.0)
+
+        else:
+            # confirm hand-checked numbers
+            q = row['query_name'].split()[0]
+            m = row['match_name'].split()[0]
+            cont = float(row['containment'])
+            jaccard = float(row['jaccard'])
+            maxcont = float(row['max_containment'])
+            intersect_hashes = int(row['intersect_hashes'])
+
+            jaccard = round(jaccard, 4)
+            cont = round(cont, 4)
+            maxcont = round(maxcont, 4)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
+
+            if q == 'GCA_001593925' and m == 'GCA_001593935':
+                assert jaccard == 0.4983
+                assert cont == 0.747
+                assert maxcont == 0.747
+                assert intersect_hashes == 1724
+
+            if q == 'GCA_001593935' and m == 'GCA_001593925':
+                assert jaccard == 0.4983
+                assert cont == 0.5994
+                assert maxcont == 0.747
+                assert intersect_hashes == 1724


### PR DESCRIPTION
## Description

This pull request introduces a new command called `pairwise`. It is similar to the existing `multisearch` command, but it uses half the memory, time, and disk space by avoiding self and bidirectional comparisons. 

usage is similar to `multisearch` except for a single positional argument of sig paths file instead of query and target.

---

## Testing

```bash
sourmash scripts multisearch sig_paths.l sig_paths.l  -c 16 -k 51 -s 10000 -o multisearch_result.csv
sourmash scripts pairwise sig_paths.l  -c 16 -k 51 -s 10000 -o pairwise_result.csv -t 0.0
```

```python
import pandas as pd
import numpy as np

df_multisearch = pd.read_csv('multisearch_result.csv')
df_pairwise = pd.read_csv('pairwise_result.csv')

multisearch_unique_query_name = set(df_multisearch['query_name'].unique())
assert len(df_pairwise) == (len(df_multisearch) - len(multisearch_unique_query_name)) // 2

df_multisearch = df_multisearch[df_multisearch['query_name'] != df_multisearch['match_name']]
df_multisearch = df_multisearch[df_multisearch['query_name'] < df_multisearch['match_name']]

assert len(df_multisearch) == len(df_pairwise)

def order_pairs(df):
    # Create a mask where query_name is greater than match_name
    mask = df['query_name'] > df['match_name']

    # Swap names and md5s where necessary
    df.loc[mask, ['query_name', 'match_name']] = df.loc[mask, ['match_name', 'query_name']].values
    df.loc[mask, ['query_md5', 'match_md5']] = df.loc[mask, ['match_md5', 'query_md5']].values

    return df

df_multisearch = order_pairs(df_multisearch)
df_pairwise = order_pairs(df_pairwise)

df_multisearch_sorted = df_multisearch.sort_values(by=['query_name', 'match_name']).reset_index(drop=True)
df_pairwise_sorted = df_pairwise.sort_values(by=['query_name', 'match_name']).reset_index(drop=True)

assert df_multisearch_sorted.equals(df_pairwise_sorted), "Dataframes are not equal"
print("Dataframes are equal")


# intetnionally modify one value in df_multisearch and check if the dataframes are still equal
random_index = np.random.randint(len(df_multisearch))
df_multisearch.at[random_index, 'max_containment'] = df_multisearch.at[random_index, 'max_containment'] + 0.01  # Modify the value slightly
df_multisearch = order_pairs(df_multisearch)
df_pairwise = order_pairs(df_pairwise)
df_multisearch_sorted = df_multisearch.sort_values(by=['query_name', 'match_name']).reset_index(drop=True)
df_pairwise_sorted = df_pairwise.sort_values(by=['query_name', 'match_name']).reset_index(drop=True)
assert df_multisearch_sorted.equals(df_pairwise_sorted), "Dataframes are not equal"
```

---

## time -v Profiling benchmark

<details><summary>multisearch</summary>

```
[K
== This is sourmash version 4.8.5. ==

[K== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==


[K=> sourmash_plugin_branchwater 0.8.6.dev0; cite Irber et al., doi: 10.1101/2022.11.02.514947


[Kksize: 51 / scaled: 10000 / moltype: DNA / threshold: 0.0

[Ksearching all sketches in 'sig_paths.l' against 'sig_paths.l' using 16 threads
Reading list of query paths from: 'sig_paths.l'
Loaded 532 query signature(s)
Reading list of search paths from: 'sig_paths.l'
Loaded 532 search signature(s)
Processed 0 comparisons
Processed 100000 comparisons
Processed 200000 comparisons
DONE. Processed 283024 comparisons

[K...multisearch is done! results in 'multisearch_result.csv'
	Command being timed: "sourmash scripts multisearch sig_paths.l sig_paths.l -c 16 -k 51 -s 10000 -o multisearch_result.csv -t 0.0"
	User time (seconds): 398.14
	System time (seconds): 4.86
	Percent of CPU this job got: 1489%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:27.06
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 3058280
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 3
	Minor (reclaiming a frame) page faults: 1068291
	Voluntary context switches: 289516
	Involuntary context switches: 271330
	Swaps: 0
	File system inputs: 0
	File system outputs: 100560
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

</details>

<details><summary>pairwise</summary>

```
[K
== This is sourmash version 4.8.5. ==

[K== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==


[K=> sourmash_plugin_branchwater 0.8.6.dev0; cite Irber et al., doi: 10.1101/2022.11.02.514947


[Kksize: 51 / scaled: 10000 / moltype: DNA / threshold: 0.0

[Kpairwise-comparing all sketches in 'sig_paths.l' using 16 threads
Reading list of query paths from: 'sig_paths.l'
Loaded 532 query signature(s)
Processed 0 comparisons
Processed 100000 comparisons
DONE. Processed 141246 comparisons

[K...pairwise is done! results in 'pairwise_result.csv'
	Command being timed: "sourmash scripts pairwise sig_paths.l -c 16 -k 51 -s 10000 -o pairwise_result.csv -t 0.0"
	User time (seconds): 198.93
	System time (seconds): 4.22
	Percent of CPU this job got: 1471%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:13.80
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1781012
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 623829
	Voluntary context switches: 142733
	Involuntary context switches: 150950
	Swaps: 0
	File system inputs: 0
	File system outputs: 50232
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

</details> 

---

resolves #114 