### PR TITLE
EXP: Show multisig loading issue

### DIFF
--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -304,17 +304,40 @@ def test_against_multisigfile(runtmp, zip_against):
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
 
+    runtmp.sourmash('scripts', 'fastgather', query, combined,
+                    '-o', g_output, '--output-prefetch', p_output,
+                    '-s', '100000')
+    df = pandas.read_csv(g_output)
+    assert len(df) == 3
+    print(df)
+
+
+def test_against_multisigfile_in_pathlist(runtmp):
+    # test against a sigfile that contains multiple sketches
+    query = get_test_data('SRR606249.sig.gz')
+    against_list = runtmp.output('against.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    combined = runtmp.output('combined.sig.gz')
+    runtmp.sourmash('sig', 'cat', sig2, sig47, sig63, '-o', combined)
+    make_file_list(against_list, [combined])
+
+    g_output = runtmp.output('gather.csv')
+    p_output = runtmp.output('prefetch.csv')
+
     runtmp.sourmash('scripts', 'fastgather', query, against_list,
                     '-o', g_output, '--output-prefetch', p_output,
                     '-s', '100000')
     df = pandas.read_csv(g_output)
-    if zip_against:
-        assert len(df) == 3
-        print(df)
-    else:
-        print(df)
-        assert len(df) == 1
+    print(df)
+    assert len(df) == 3
     # @CTB this is a bug :(. It should load multiple sketches properly!
+    # @NTP: see pathlist loading in load_collection. When we build
+    # records from a signature, all records from the same signature
+    # are read in, but end up having the same name/md5sum
 
 
 @pytest.mark.parametrize('zip_against', [False, True])

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -252,7 +252,12 @@ pub fn load_sketches_above_threshold(
             // Load against into memory
             if let Ok(against_sig) = against_collection.sig_from_record(against_record) {
                 if let Some(against_mh) = against_sig.minhash() {
-                    // if let Some(against_mh) = against_sig.select(&selection).unwrap().minhash() { // downsample via select
+                    eprintln!(
+                        "against_sig info: name: {}, md5:{},",
+                        against_sig.name(),
+                        against_sig.md5sum()
+                    );
+                    eprintln!("against_mh info:  md5:{},", against_mh.md5sum());
                     // currently downsampling here to avoid changing md5sum
                     if let Ok(overlap) = against_mh.count_common(query, true) {
                         //downsample via count_common
@@ -356,6 +361,8 @@ pub fn load_collection(
                         let path = line.ok()?;
                         match Signature::from_path(&path) {
                             Ok(signatures) => {
+                                // TODO: Handling for multisig files: Split into separate sigs so records are unique?
+                                // Currently, we end up with a single record
                                 let recs: Vec<Record> = signatures
                                     .into_iter()
                                     .flat_map(|v| Record::from_sig(&v, &path))
@@ -374,6 +381,7 @@ pub fn load_collection(
                     .collect();
 
                 let manifest: Manifest = records.into();
+                eprintln!("len manifest: {}", manifest.len());
                 Collection::new(
                     manifest,
                     InnerStorage::new(


### PR DESCRIPTION
with #197, we can load multisigs just fine from sigfiles and from zipfiles. I thought it would be straightforward to handle for pathlists too, but am punting.

The issue is in using `record::from_sig`, which builds a single manifest record from the sig. 