### PR TITLE
MRG: update docs for v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "sourmash_plugin_branchwater"
-version = "0.8.7-dev"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,52 +50,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "anyhow"
@@ -360,12 +318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,26 +418,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
+name = "env_logger"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
+ "humantime",
+ "is-terminal",
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e7cf40684ae96ade6232ed84582f40ce0a66efcd43a5117aef610534f8e0b8"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
+ "termcolor",
 ]
 
 [[package]]
@@ -582,6 +524,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+
+[[package]]
 name = "histogram"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +580,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1554,6 +1513,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,12 +1604,6 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -1756,6 +1718,37 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ sourmash = { version = "0.12.1", features = ["branchwater"] }
 serde_json = "1.0.113"
 niffler = "2.4.0"
 log = "0.4.14"
-env_logger = "0.11.1"
+env_logger = "0.10.2"
 simple-error = "0.3.0"
 anyhow = "1.0.79"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash_plugin_branchwater"
-version = "0.8.7-dev"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/doc/README.md
+++ b/doc/README.md
@@ -15,12 +15,13 @@ The main *drawback* to these plugin commands is that their inputs and outputs ar
 
 ## Input file formats
 
-sourmash supports a variety of different storage formats for sketches (see [sourmash docs](https://sourmash.readthedocs.io/en/latest/command-line.html#choosing-signature-output-formats)), and the branchwater plugin works some (but not all) of them. Branchwater _also_ supports an additional database type, a RocksDB-based inverted index, that is not yet supported by sourmash (through v4.8.6).
+sourmash supports a variety of different storage formats for sketches (see [sourmash docs](https://sourmash.readthedocs.io/en/latest/command-line.html#choosing-signature-output-formats)), and the branchwater plugin works with some (but not all) of them. Branchwater _also_ supports an additional database type, a RocksDB-based inverted index, that is not yet supported by sourmash (through v4.8.6).
 
 **As of v0.9.0, we recommend using zip files or manifest CSVs whenever you need to provide multiple sketches.**
 
 | command | query input | database format |
 | -------- | -------- | -------- |
+| `manysketch`     | CSV with input fasta/fastq paths (details below)    | _produces_ Zip database |
 | `gather`     | Single metagenome in sig, zip, manifest CSV, or fromfile     | Zip, manifest CSV, or fromfile |
 | `fastmultigather` | Multiple metagenomes in sig, zip, manifest CSV, or fromfile | Zip, manifest CSV, fromfile, or rocksdb index |
 | `manysearch` | Multiple genomes in sig, zip, manifest CSV, or fromfile | Zip, manifest CSV, fromfile, or rocksdb index |
@@ -29,7 +30,7 @@ sourmash supports a variety of different storage formats for sketches (see [sour
 
 ### Using zipfiles
 
-When working with large collections of small sketches such as genomes, we suggest using zipfiles as produced by sourmash (e.g. using `sourmash sig cat`). Zip files have a few nice features:
+When working with large collections of small sketches such as genomes, we suggest using zipfiles as produced by sourmash (e.g. using `sourmash sig cat` or `manysketch`). Zip files have a few nice features:
 
 * sketches are compressed in zip files;
 * zip files can contain many sketches, including incompatible types (e.g. multiple k-mer sizes);

--- a/doc/README.md
+++ b/doc/README.md
@@ -9,7 +9,7 @@
 | `multisearch` | Multithreaded comparison of multiple sketches, in memory | [link](#Running-multisearch)
 | `pairwise` | Multithreaded pairwise comparison of multiple sketches, in memory | [link](#Running-multisearch)
 
-This repository implements multithreaded plugins for [sourmash](https://sourmash.readthedocs.io/) that provide very fast implementations of `sketch`, `search`, and `gather`. These commands are typically hundreds to thousands of times faster, and 10-50x lower memory, than the current sourmash code.
+This repository implements multithreaded plugins for [sourmash](https://sourmash.readthedocs.io/) that provide very fast implementations of `sketch`, `search`, and `gather`. These commands are typically hundreds to thousands of times faster, and 10-50x lower memory, than the current sourmash code. For example, a `gather` of SRR606249 with sourmash v4.8.6 against GTDB rs214 takes 40 minutes and 14 GB of RAM, while `fastgather` takes only 2 minutes and 2 GB of RAM.
 
 The main *drawback* to these plugin commands is that their inputs and outputs are not as rich as the native sourmash commands. This means that your input files may need to be prepared differently, and the output may in some cases be most useful as a prefilter in conjunction with regular sourmash commands - see the instructions below for using `fastgather` to create picklists for sourmash.
 
@@ -49,7 +49,7 @@ sourmash sig cat <list of sketches> -o sigs.zip
 There are various places where we recommend using manifests instead of zip files. Why?
 
 Well, first, if you are using a zip file created by sourmash, you are already using a manifest! And you will get all of the benefits described above!
-
+ 
 But if you want to use a collection of multiple very large metagenomes (as search targets in `manysearch`, or as queries in `fastmultigather`), then standalone manifests might be a good solution for you.
 
 This is for two specific reasons:

--- a/doc/README.md
+++ b/doc/README.md
@@ -105,6 +105,11 @@ sourmash scripts multisearch list.query.txt list.gtdb-rs214-k21.txt  -o query.x.
 
 The results file here, `query.x.gtdb-reps.csv`, will have 8 columns: `query` and `query_md5`, `match` and `match_md5`, and `containment`, `jaccard`, `max_containment`, and `intersect_hashes`.
 
+The `pairwise` command does the same thing as `multisearch` but takes
+only a single file, which it uses to calculate all pairwise
+comparisons. Since the comparisons are symmetric, it is a bit more than
+twice as fast as `multisearch`.
+
 ### Running `fastgather`
 
 The `fastgather` command is a much faster version of `sourmash gather`.
@@ -202,4 +207,8 @@ The command `sourmash scripts index` makes an on-disk inverted index
 for low memory fast search. Indexing takes a while, but then search
 takes fewer resources.
 
-Currently only fastmultigather and manysearch can use this kind of inde.
+Currently only `fastmultigather` and `manysearch` can use this kind of index.
+
+We suggest using the extension `.rocksdb` for these databases, as we
+use [RocksDB](https://rocksdb.org/) for the underlying database storage
+mechanism.

--- a/doc/README.md
+++ b/doc/README.md
@@ -9,7 +9,7 @@
 | `multisearch` | Multithreaded comparison of multiple sketches, in memory | [link](#Running-multisearch)
 | `pairwise` | Multithreaded pairwise comparison of multiple sketches, in memory | [link](#Running-multisearch)
 
-This repository implements multithreaded plugins for [sourmash](https://sourmash.readthedocs.io/) that provide very fast implementations of `sketch`, `search`, and `gather`. These commands are typically hundreds to thousands of times faster, and 10-50x lower memory, than the current sourmash code. For example, a `gather` of SRR606249 with sourmash v4.8.6 against GTDB rs214 takes 40 minutes and 14 GB of RAM, while `fastgather` takes only 2 minutes and 2 GB of RAM.
+This repository implements multithreaded plugins for [sourmash](https://sourmash.readthedocs.io/) that provide very fast implementations of `sketch`, `search`, and `gather`. These commands are typically hundreds to thousands of times faster, and 10-50x lower memory, than the current sourmash code. For example, a `gather` of SRR606249 with sourmash v4.8.6 against GTDB rs214 takes 40 minutes and 14 GB of RAM, while `fastgather` with 64 cores takes only 2 minutes and 2 GB of RAM.
 
 The main *drawback* to these plugin commands is that their inputs and outputs are not as rich as the native sourmash commands. This means that your input files may need to be prepared differently, and the output may in some cases be most useful as a prefilter in conjunction with regular sourmash commands - see the instructions below for using `fastgather` to create picklists for sourmash.
 
@@ -17,7 +17,7 @@ The main *drawback* to these plugin commands is that their inputs and outputs ar
 
 sourmash supports a variety of different storage formats for sketches (see [sourmash docs](https://sourmash.readthedocs.io/en/latest/command-line.html#choosing-signature-output-formats)), and the branchwater plugin works some (but not all) of them. Branchwater _also_ supports an additional database type, a RocksDB-based inverted index, that is not yet supported by sourmash (through v4.8.6).
 
-**As of v0.9.0, we recommend using zip files or manifest CSVs whenever you need to provide multiple sketches.** Prior to v0.9.0, we suggest fromfiles, but these now incur substantial overhead.
+**As of v0.9.0, we recommend using zip files or manifest CSVs whenever you need to provide multiple sketches.**
 
 | command | query input | database format |
 | -------- | -------- | -------- |

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -465,35 +465,32 @@ pub fn load_collection(
         None
     };
 
-    let collection = collection.or_else(|| {
-        match collection_from_manifest(&sigpath, &report_type) {
+    let collection =
+        collection.or_else(|| match collection_from_manifest(&sigpath, &report_type) {
             Ok(coll) => Some((coll, 0)),
             Err(e) => {
                 last_error = Some(e);
                 None
             }
-        }
-    });
+        });
 
-    let collection = collection.or_else(|| {
-        match collection_from_signature(&sigpath, &report_type) {
+    let collection =
+        collection.or_else(|| match collection_from_signature(&sigpath, &report_type) {
             Ok(coll) => Some((coll, 0)),
             Err(e) => {
                 last_error = Some(e);
                 None
             }
-        }
-    });
+        });
 
-    let collection = collection.or_else(|| {
-        match collection_from_pathlist(&sigpath, &report_type) {
+    let collection =
+        collection.or_else(|| match collection_from_pathlist(&sigpath, &report_type) {
             Ok((coll, n_failed)) => Some((coll, n_failed)),
             Err(e) => {
                 last_error = Some(e);
                 None
             }
-        }
-    });
+        });
 
     match collection {
         Some((coll, n_failed)) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -466,7 +466,6 @@ pub fn load_collection(
     };
 
     let collection = collection.or_else(|| {
-        // dbg!("attempting to load as manifest");
         match collection_from_manifest(&sigpath, &report_type) {
             Ok(coll) => Some((coll, 0)),
             Err(e) => {
@@ -477,7 +476,6 @@ pub fn load_collection(
     });
 
     let collection = collection.or_else(|| {
-        // dbg!("attempting to load as signature");
         match collection_from_signature(&sigpath, &report_type) {
             Ok(coll) => Some((coll, 0)),
             Err(e) => {
@@ -488,7 +486,6 @@ pub fn load_collection(
     });
 
     let collection = collection.or_else(|| {
-        // dbg!("attempting to load as pathlist");
         match collection_from_pathlist(&sigpath, &report_type) {
             Ok((coll, n_failed)) => Some((coll, n_failed)),
             Err(e) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -458,7 +458,7 @@ pub fn load_collection(
     };
 
     let collection = collection.or_else(|| {
-        dbg!("attempting to load as manifest");
+        // dbg!("attempting to load as manifest");
         match collection_from_manifest(&sigpath, &report_type) {
             Ok(coll) => Some((coll, 0)),
             Err(e) => {
@@ -469,7 +469,7 @@ pub fn load_collection(
     });
 
     let collection = collection.or_else(|| {
-        dbg!("attempting to load as signature");
+        // dbg!("attempting to load as signature");
         match collection_from_signature(&sigpath, &report_type) {
             Ok(coll) => Some((coll, 0)),
             Err(e) => {
@@ -480,7 +480,7 @@ pub fn load_collection(
     });
 
     let collection = collection.or_else(|| {
-        dbg!("attempting to load as pathlist");
+        // dbg!("attempting to load as pathlist");
         match collection_from_pathlist(&sigpath, &report_type) {
             Ok((coll, n_failed)) => Some((coll, n_failed)),
             Err(e) => {


### PR DESCRIPTION
After https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/197 and https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/211, we need to switch up our documentation and references for using the branchwater plugin.

This PR also adds documentation for `pairwise` and suggests `.rocksdb` as the suffix for `index` output.

Finally, this PR bumps the version to v0.9.0 in preparation for a release. 🎉 

The updated `doc/README.md` is [here](https://github.com/sourmash-bio/sourmash_plugin_branchwater/blob/update_docs2/doc/README.md).

HackMD version of `doc/README.md` for nicer viewing/editing: https://hackmd.io/_DqWfa8BS364lfjhnvfnOg?view

- Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/212
- Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/210
- Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/190

