### PR TITLE
MRG: Use `core` manifest utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -226,9 +226,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -327,9 +327,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -583,9 +583,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "histogram"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ee9487899388cf1a1155759c39e3c156c5d198b6da1734053954a6e40e6d4d"
+checksum = "4b634390eb8a63662e127836d4e2f26d7ae930600d4e05ee0fd85a009eeb1175"
 dependencies = [
  "thiserror",
 ]
@@ -660,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
  "pkg-config",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1267,9 +1267,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
@@ -1437,8 +1437,7 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 [[package]]
 name = "sourmash"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8187a00787432261dc522b6ebf813251dbbeabc04ed7a47f5cbb9be0d4a508"
+source = "git+https://github.com/sourmash-bio/sourmash?rev=375ddb2ed25afbffc2ffa981c627256b195bf794#375ddb2ed25afbffc2ffa981c627256b195bf794"
 dependencies = [
  "az",
  "byteorder",
@@ -1693,9 +1692,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1705,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -1720,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1730,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1743,15 +1742,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,8 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 [[package]]
 name = "sourmash"
 version = "0.13.0"
-source = "git+https://github.com/sourmash-bio/sourmash?rev=297ff0b963adbed7462508ea1247fe192be02b98#297ff0b963adbed7462508ea1247fe192be02b98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9e413cb7387bbb4405e960920e5d8c5f255ec4a86f021a18a455014565e749"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "byteorder"
@@ -1275,12 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "retain_mut"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
-
-[[package]]
 name = "rkyv"
 version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,13 +1305,12 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6106b5cf8587f5834158895e9715a3c6c9716c8aefab57f1f7680917191c7873"
+checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
 dependencies = [
  "bytemuck",
  "byteorder",
- "retain_mut",
 ]
 
 [[package]]
@@ -1436,8 +1429,8 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 
 [[package]]
 name = "sourmash"
-version = "0.12.1"
-source = "git+https://github.com/sourmash-bio/sourmash?rev=296e4b49ba73e4afaafbb2612e952464fdafdb5b#296e4b49ba73e4afaafbb2612e952464fdafdb5b"
+version = "0.13.0"
+source = "git+https://github.com/sourmash-bio/sourmash?rev=45a7ad843c76cdcdcf0ae0347f4711481654cbd0#45a7ad843c76cdcdcf0ae0347f4711481654cbd0"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +781,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +840,35 @@ name = "murmurhash3"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2983372caf4480544083767bf2d27defafe32af49ab4df3a0b7fc90793a3664"
+
+[[package]]
+name = "nalgebra"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "needletail"
@@ -868,6 +922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num-complex"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,12 +952,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -950,6 +1025,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "peeking_take_while"
@@ -1208,6 +1289,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roots"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082f11ffa03bbef6c2c6ea6bea1acafaade2fd9050ae0234ab44a2153742b058"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1450,15 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "safemem"
@@ -1404,6 +1516,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simba"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,7 +1555,7 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 [[package]]
 name = "sourmash"
 version = "0.13.0"
-source = "git+https://github.com/sourmash-bio/sourmash?rev=45a7ad843c76cdcdcf0ae0347f4711481654cbd0#45a7ad843c76cdcdcf0ae0347f4711481654cbd0"
+source = "git+https://github.com/sourmash-bio/sourmash?rev=297ff0b963adbed7462508ea1247fe192be02b98#297ff0b963adbed7462508ea1247fe192be02b98"
 dependencies = [
  "az",
  "byteorder",
@@ -1444,6 +1569,7 @@ dependencies = [
  "getrandom",
  "getset",
  "histogram",
+ "itertools",
  "log",
  "md5",
  "memmap2",
@@ -1459,8 +1585,11 @@ dependencies = [
  "rkyv",
  "roaring",
  "rocksdb",
+ "roots",
  "serde",
  "serde_json",
+ "statrs",
+ "streaming-stats",
  "thiserror",
  "twox-hash",
  "typed-builder",
@@ -1498,6 +1627,28 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d08e5e1748192713cc281da8b16924fb46be7b0c2431854eadc785823e5696e"
+dependencies = [
+ "approx",
+ "lazy_static",
+ "nalgebra",
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "streaming-stats"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d670ce4e348a2081843569e0f79b21c99c91bb9028b3b3ecb0f050306de547"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "syn"
@@ -1616,6 +1767,12 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
@@ -1747,6 +1904,16 @@ checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89beec544f246e679fc25490e3f8e08003bc4bf612068f325120dad4cea02c1c"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,7 +1437,7 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 [[package]]
 name = "sourmash"
 version = "0.12.1"
-source = "git+https://github.com/sourmash-bio/sourmash?rev=375ddb2ed25afbffc2ffa981c627256b195bf794#375ddb2ed25afbffc2ffa981c627256b195bf794"
+source = "git+https://github.com/sourmash-bio/sourmash?rev=296e4b49ba73e4afaafbb2612e952464fdafdb5b#296e4b49ba73e4afaafbb2612e952464fdafdb5b"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.20.2", features = ["extension-module", "anyhow"] }
 rayon = "1.8.1"
 serde = { version = "1.0.196", features = ["derive"] }
-sourmash = { version = "0.12.1", features = ["branchwater"] }
+#sourmash = { version = "0.12.1", features = ["branchwater"] }
+sourmash = { git="https://github.com/sourmash-bio/sourmash", rev="375ddb2ed25afbffc2ffa981c627256b195bf794", features = ["branchwater"] }
 serde_json = "1.0.113"
 niffler = "2.4.0"
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.20.2", features = ["extension-module", "anyhow"] }
 rayon = "1.8.1"
 serde = { version = "1.0.196", features = ["derive"] }
-#sourmash = { version = "0.12.1", features = ["branchwater"] }
-sourmash = { git="https://github.com/sourmash-bio/sourmash", rev="297ff0b963adbed7462508ea1247fe192be02b98", features = ["branchwater"] }
+sourmash = { version = "0.13.0", features = ["branchwater"] }
 serde_json = "1.0.113"
 niffler = "2.4.0"
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pyo3 = { version = "0.20.2", features = ["extension-module", "anyhow"] }
 rayon = "1.8.1"
 serde = { version = "1.0.196", features = ["derive"] }
 #sourmash = { version = "0.12.1", features = ["branchwater"] }
-sourmash = { git="https://github.com/sourmash-bio/sourmash", rev="45a7ad843c76cdcdcf0ae0347f4711481654cbd0", features = ["branchwater"] }
+sourmash = { git="https://github.com/sourmash-bio/sourmash", rev="297ff0b963adbed7462508ea1247fe192be02b98", features = ["branchwater"] }
 serde_json = "1.0.113"
 niffler = "2.4.0"
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pyo3 = { version = "0.20.2", features = ["extension-module", "anyhow"] }
 rayon = "1.8.1"
 serde = { version = "1.0.196", features = ["derive"] }
 #sourmash = { version = "0.12.1", features = ["branchwater"] }
-sourmash = { git="https://github.com/sourmash-bio/sourmash", rev="375ddb2ed25afbffc2ffa981c627256b195bf794", features = ["branchwater"] }
+sourmash = { git="https://github.com/sourmash-bio/sourmash", rev="296e4b49ba73e4afaafbb2612e952464fdafdb5b", features = ["branchwater"] }
 serde_json = "1.0.113"
 niffler = "2.4.0"
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pyo3 = { version = "0.20.2", features = ["extension-module", "anyhow"] }
 rayon = "1.8.1"
 serde = { version = "1.0.196", features = ["derive"] }
 #sourmash = { version = "0.12.1", features = ["branchwater"] }
-sourmash = { git="https://github.com/sourmash-bio/sourmash", rev="296e4b49ba73e4afaafbb2612e952464fdafdb5b", features = ["branchwater"] }
+sourmash = { git="https://github.com/sourmash-bio/sourmash", rev="45a7ad843c76cdcdcf0ae0347f4711481654cbd0", features = ["branchwater"] }
 serde_json = "1.0.113"
 niffler = "2.4.0"
 log = "0.4.14"

--- a/src/check.rs
+++ b/src/check.rs
@@ -8,7 +8,7 @@ pub fn check(index: camino::Utf8PathBuf, quick: bool) -> Result<(), Box<dyn std:
     }
 
     println!("Opening DB");
-    let db = RevIndex::open(index, true)?;
+    let db = RevIndex::open(index, true, None)?;
 
     println!("Starting check");
     db.check(quick);

--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -8,6 +8,7 @@ use crate::utils::{
     ReportType,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub fn fastgather(
     query_filepath: String,
     against_filepath: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ fn do_manysearch(
 }
 
 #[pyfunction]
+#[allow(clippy::too_many_arguments)]
 fn do_fastgather(
     query_filename: String,
     siglist_path: String,

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -99,7 +99,6 @@ fn build_siginfo(params: &[Params], moltype: &str) -> Vec<Signature> {
 
         let cp = ComputeParameters::builder()
             .ksizes(vec![adjusted_ksize])
-            // .ksizes(vec![param.ksize])
             .scaled(param.scaled)
             .protein(param.is_protein)
             .dna(param.is_dna)

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -223,11 +223,11 @@ pub fn manysketch(
                 sig.set_name(name);
                 sig.set_filename(filename.as_str());
             });
-            Some((sigs))
+            Some(sigs)
         })
         .try_for_each_with(
             send.clone(),
-            |s: &mut std::sync::Arc<std::sync::mpsc::SyncSender<ZipMessage>>, (sigs)| {
+            |s: &mut std::sync::Arc<std::sync::mpsc::SyncSender<ZipMessage>>, sigs| {
                 if let Err(e) = s.send(ZipMessage::SignatureData(sigs)) {
                     Err(format!("Unable to send internal data: {:?}", e))
                 } else {

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -197,12 +197,18 @@ pub fn manysketch(
                 }
             };
             // parse fasta and add to signature
+            let mut set_name = false;
             while let Some(record_result) = reader.next() {
                 match record_result {
                     Ok(record) => {
                         // do we need to normalize to make sure all the bases are consistently capitalized?
                         // let norm_seq = record.normalize(false);
                         sigs.iter_mut().for_each(|sig| {
+                            if !set_name {
+                                sig.set_name(name);
+                                sig.set_filename(filename.as_str());
+                                set_name = true;
+                            };
                             if moltype == "protein" {
                                 sig.add_protein(&record.seq())
                                     .expect("Failed to add protein");
@@ -217,11 +223,6 @@ pub fn manysketch(
                 }
             }
 
-            // Set name and filename for each signature after processing all records
-            sigs.iter_mut().for_each(|sig| {
-                sig.set_name(name);
-                sig.set_filename(filename.as_str());
-            });
             Some(sigs)
         })
         .try_for_each_with(

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -99,6 +99,7 @@ fn build_siginfo(params: &[Params], moltype: &str) -> Vec<Signature> {
 
         let cp = ComputeParameters::builder()
             .ksizes(vec![adjusted_ksize])
+            // .ksizes(vec![param.ksize])
             .scaled(param.scaled)
             .protein(param.is_protein)
             .dna(param.is_dna)

--- a/src/mastiff_manygather.rs
+++ b/src/mastiff_manygather.rs
@@ -23,7 +23,7 @@ pub fn mastiff_manygather(
         bail!("'{}' is not a valid RevIndex database", index);
     }
     // Open database once
-    let db = RevIndex::open(index, true)?;
+    let db = RevIndex::open(index, true, None)?;
     println!("Loaded DB");
 
     let query_collection = load_collection(

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -24,7 +24,7 @@ pub fn mastiff_manysearch(
         bail!("'{}' is not a valid RevIndex database", index);
     }
     // Open database once
-    let db = RevIndex::open(index, true)?;
+    let db = RevIndex::open(index, true, None)?;
 
     println!("Loaded DB");
 

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -669,8 +669,8 @@ def test_simple_with_manifest_loading(runtmp):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
-    query_manifest = get_test_data("query-manifest.csv")
-    against_manifest = get_test_data("against-manifest.csv")
+    query_manifest = runtmp.output("query-manifest.csv")
+    against_manifest = runtmp.output("against-manifest.csv")
 
     runtmp.sourmash("sig", "manifest", query, "-o", query_manifest)
     runtmp.sourmash("sig", "manifest", against_list, "-o", against_manifest)

--- a/src/python/tests/test_sketch.py
+++ b/src/python/tests/test_sketch.py
@@ -13,11 +13,14 @@ def get_test_data(filename):
 
 
 def make_file_csv(filename, genome_paths, protein_paths = []):
+    # equalize path lengths by adding "".
     names = [os.path.basename(x).split('.fa')[0] for x in genome_paths]
-    # Check if the number of protein paths is less than genome paths
-    # and fill in the missing paths with "".
     if len(protein_paths) < len(genome_paths):
         protein_paths.extend(["" for _ in range(len(genome_paths) - len(protein_paths))])
+    elif len(genome_paths) < len(protein_paths):
+        genome_paths.extend(["" for _ in range(len(protein_paths) - len(genome_paths))])
+        names = [os.path.basename(x).split('.fa')[0] for x in protein_paths]
+
     with open(filename, 'wt') as fp:
         fp.write("name,genome_filename,protein_filename\n")
         for name, genome_path, protein_path in zip(names, genome_paths, protein_paths):
@@ -404,4 +407,48 @@ def test_zip_manifest(runtmp, capfd):
         assert sig in manifest
         assert sig.minhash.ksize == 31
         assert sig.minhash.moltype == 'DNA'
+        assert sig.minhash.scaled == 1
+
+
+def test_protein_zip_manifest(runtmp, capfd):
+    # test basic manifest-generating functionality.
+    fa_csv = runtmp.output('db-fa.csv')
+
+    fa1 = get_test_data('short.fa')
+    fa2 = get_test_data('short-protein.fa')
+
+    make_file_csv(fa_csv, [fa1], [fa2])
+    output = runtmp.output('db.zip')
+
+    runtmp.sourmash('scripts', 'manysketch', fa_csv, '-o', output,
+                    '--param-str', "protein,k=10,scaled=1")
+
+    loader = sourmash.load_file_as_index(output)
+
+    rows = []
+    siglist = []
+    # make manifest via sourmash python code
+    for (sig, loc) in loader._signatures_with_internal():
+        row = index.CollectionManifest.make_manifest_row(sig, loc)
+        rows.append(row)
+        siglist.append(sig)
+
+    manifest = index.CollectionManifest(rows)
+
+    assert len(manifest) == len(rows)
+    assert len(manifest) == 1
+
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert 'eb4467d11e0ecd2dbde4193bfc255310' in md5_list
+    ksize_list = [ row['ksize'] for row in manifest.rows ]
+    assert 10 in ksize_list
+    scaled_list = [ row['scaled'] for row in manifest.rows ]
+    assert 1 in scaled_list
+    moltype_list = [ row['moltype'] for row in manifest.rows ]
+    assert "protein" in moltype_list
+
+    for sig in siglist:
+        assert sig in manifest
+        assert sig.minhash.ksize == 10
+        assert sig.minhash.moltype == 'protein'
         assert sig.minhash.scaled == 1

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -837,7 +837,6 @@ pub fn sigwriter(
                         };
                         write_signature(sig, &mut zip, options, &sig_filename);
                         let records: Vec<Record> = Record::from_sig(&sig, &sig_filename.as_str());
-                        eprintln!("{:?}", &records);
                         manifest_rows.extend(records);
                     }
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -375,11 +375,11 @@ fn collection_from_pathlist(
     let n_failed = AtomicUsize::new(0);
     let records: Vec<Record> = lines
         .par_iter()
-        .filter_map(|path| match Signature::from_path(&path) {
+        .filter_map(|path| match Signature::from_path(path) {
             Ok(signatures) => {
                 let recs: Vec<Record> = signatures
                     .into_iter()
-                    .flat_map(|v| Record::from_sig(&v, &path))
+                    .flat_map(|v| Record::from_sig(&v, path))
                     .collect();
                 Some(recs)
             }
@@ -844,7 +844,7 @@ pub fn sigwriter(
                             format!("signatures/{}.sig.gz", md5sum_str)
                         };
                         write_signature(sig, &mut zip, options, &sig_filename);
-                        let records: Vec<Record> = Record::from_sig(&sig, &sig_filename.as_str());
+                        let records: Vec<Record> = Record::from_sig(sig, sig_filename.as_str());
                         manifest_rows.extend(records);
                     }
                 }


### PR DESCRIPTION
This PR updates manifest generation in `manysketch` to use `Record` and `Manifest` utils from core. This also makes the code significantly simpler, since we can generate manifest information directly from the signature, rather than saving sketch parameters alongside sketches. 

Required `0.13.0` core due to these fixes:
- https://github.com/sourmash-bio/sourmash/pull/3007
- https://github.com/sourmash-bio/sourmash/pull/3019

* Fixes #203

