### PR TITLE
MRG: parallelize `collection_from_pathlist`

### DIFF
--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -669,8 +669,8 @@ def test_simple_with_manifest_loading(runtmp):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
-    query_manifest = get_test_data("query-manifest.csv")
-    against_manifest = get_test_data("against-manifest.csv")
+    query_manifest = runtmp.output("query-manifest.csv")
+    against_manifest = runtmp.output("against-manifest.csv")
 
     runtmp.sourmash("sig", "manifest", query, "-o", query_manifest)
     runtmp.sourmash("sig", "manifest", against_list, "-o", against_manifest)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -367,11 +367,9 @@ fn collection_from_pathlist(
     // load list of paths
     let lines: Vec<_> = reader
         .lines()
-        .filter_map(|line| {
-            match line {
-                Ok(path) => Some(path),
-                Err(_err) => None
-            }
+        .filter_map(|line| match line {
+            Ok(path) => Some(path),
+            Err(_err) => None,
         })
         .collect();
 
@@ -379,21 +377,19 @@ fn collection_from_pathlist(
     let n_failed = AtomicUsize::new(0);
     let records: Vec<Record> = lines
         .par_iter()
-        .filter_map(|path| {
-            match Signature::from_path(&path) {
-                Ok(signatures) => {
-                    let recs: Vec<Record> = signatures
-                        .into_iter()
-                        .flat_map(|v| Record::from_sig(&v, &path))
-                        .collect();
-                    Some(recs)
-                }
-                Err(err) => {
-                    eprintln!("Sketch loading error: {}", err);
-                    eprintln!("WARNING: could not load sketches from path '{}'", path);
-                    let _ = n_failed.fetch_add(1, atomic::Ordering::SeqCst);
-                    None
-                }
+        .filter_map(|path| match Signature::from_path(&path) {
+            Ok(signatures) => {
+                let recs: Vec<Record> = signatures
+                    .into_iter()
+                    .flat_map(|v| Record::from_sig(&v, &path))
+                    .collect();
+                Some(recs)
+            }
+            Err(err) => {
+                eprintln!("Sketch loading error: {}", err);
+                eprintln!("WARNING: could not load sketches from path '{}'", path);
+                let _ = n_failed.fetch_add(1, atomic::Ordering::SeqCst);
+                None
             }
         })
         .flatten()


### PR DESCRIPTION
This PR updates `collection_from_pathlist` to first load the list of paths, and then load them all in parallel; previously, in #211, the sketches were all loaded in serial, resulting in an 18x fold slowdown vs other methods.

Benchmark proof: https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/214#issuecomment-1950646175

It also fixes a test to write manifests to the temp directory rather than the `test-data` directory.

Fixes #220

