### PR TITLE
MRG: fix manifest protein k-mer sizes

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -787,11 +787,16 @@ pub fn make_manifest_row(
         "protein".to_string()
     };
     let sketch = &sig.sketches()[0];
+    let ksize: u32 = if is_dna {
+        sketch.ksize() as u32
+    } else {
+        sketch.ksize() as u32 / 3
+    };
     ManifestRow {
         internal_location: internal_location.to_string(),
         md5: sig.md5sum(),
         md5short: sig.md5sum()[0..8].to_string(),
-        ksize: sketch.ksize() as u32,
+        ksize: ksize,
         moltype,
         num,
         scaled,


### PR DESCRIPTION
In sourmash, protein k-mer sizes are k=k*3 internally, but manifest ksizes are just k. 

So we need to remember to do some conversions :)

In the python manifest-making code, `minhash.ksize()` does the conversion back for us, so we ignore. In rust, `sketch.ksize()` does not convert back for us, so when we go to get k-mer sizes for the manifest, we need to convert back (k/3) to get the original ksize.

Fixes #216 