### PR TITLE
MRG: Add ANI output to `pairwise`, `multisearch`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,7 @@ fn do_multisearch(
     ksize: u8,
     scaled: usize,
     moltype: String,
+    estimate_ani: bool,
     output_path: Option<String>,
 ) -> anyhow::Result<u8> {
     let selection = build_selection(ksize, scaled, &moltype);
@@ -217,8 +218,9 @@ fn do_multisearch(
         siglist_path,
         threshold,
         &selection,
-        output_path,
         allow_failed_sigpaths,
+        estimate_ani,
+        output_path,
     ) {
         Ok(_) => Ok(0),
         Err(e) => {
@@ -235,16 +237,19 @@ fn do_pairwise(
     ksize: u8,
     scaled: usize,
     moltype: String,
+    estimate_ani: bool,
     output_path: Option<String>,
 ) -> anyhow::Result<u8> {
     let selection = build_selection(ksize, scaled, &moltype);
     let allow_failed_sigpaths = true;
+    eprintln!("{}", estimate_ani);
     match pairwise::pairwise(
         siglist_path,
         threshold,
         &selection,
-        output_path,
         allow_failed_sigpaths,
+        estimate_ani,
+        output_path,
     ) {
         Ok(_) => Ok(0),
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,6 @@ fn do_pairwise(
 ) -> anyhow::Result<u8> {
     let selection = build_selection(ksize, scaled, &moltype);
     let allow_failed_sigpaths = true;
-    eprintln!("{}", estimate_ani);
     match pairwise::pairwise(
         siglist_path,
         threshold,

--- a/src/multisearch.rs
+++ b/src/multisearch.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::AtomicUsize;
 use crate::utils::{
     csvwriter_thread, load_collection, load_sketches, MultiSearchResult, ReportType,
 };
+use sourmash::ani_utils::ani_from_containment;
 
 /// Search many queries against a list of signatures.
 ///
@@ -56,6 +57,7 @@ pub fn multisearch(
     //
 
     let processed_cmp = AtomicUsize::new(0);
+    let ksize = selection.ksize().unwrap() as f64;
 
     let send = against
         .par_iter()
@@ -74,9 +76,15 @@ pub fn multisearch(
                 let target_size = against.minhash.size() as f64;
 
                 let containment_query_in_target = overlap / query_size;
-                let containment_in_target = overlap / target_size;
-                let max_containment = containment_query_in_target.max(containment_in_target);
+                let containment_target_in_query = overlap / target_size;
+                let max_containment = containment_query_in_target.max(containment_target_in_query);
                 let jaccard = overlap / (target_size + query_size - overlap);
+
+                // estimate ANI values
+                let query_ani = ani_from_containment(containment_query_in_target, ksize) * 100.0;
+                let match_ani = ani_from_containment(containment_target_in_query, ksize) * 100.0;
+                let average_containment_ani = (query_ani + match_ani) / 2.;
+                let max_containment_ani = f64::max(query_ani, match_ani);
 
                 if containment_query_in_target > threshold {
                     results.push(MultiSearchResult {
@@ -88,6 +96,10 @@ pub fn multisearch(
                         max_containment,
                         jaccard,
                         intersect_hashes: overlap,
+                        query_ani,
+                        match_ani,
+                        average_containment_ani,
+                        max_containment_ani,
                     })
                 }
             }

--- a/src/multisearch.rs
+++ b/src/multisearch.rs
@@ -77,25 +77,27 @@ pub fn multisearch(
                 let target_size = against.minhash.size() as f64;
 
                 let containment_query_in_target = overlap / query_size;
-                let containment_target_in_query = overlap / target_size;
-                let max_containment = containment_query_in_target.max(containment_target_in_query);
-                let jaccard = overlap / (target_size + query_size - overlap);
-
-                // estimate ANI values
-                let mut query_ani = None;
-                let mut match_ani = None;
-                let mut average_containment_ani = None;
-                let mut max_containment_ani = None;
-                if estimate_ani {
-                    let qani = ani_from_containment(containment_query_in_target, ksize) * 100.0;
-                    let mani = ani_from_containment(containment_target_in_query, ksize) * 100.0;
-                    query_ani = Some(qani);
-                    match_ani = Some(mani);
-                    average_containment_ani = Some((qani + mani) / 2.);
-                    max_containment_ani = Some(f64::max(qani, mani));
-                }
 
                 if containment_query_in_target > threshold {
+                    let containment_target_in_query = overlap / target_size;
+                    let max_containment =
+                        containment_query_in_target.max(containment_target_in_query);
+                    let jaccard = overlap / (target_size + query_size - overlap);
+                    let mut query_ani = None;
+                    let mut match_ani = None;
+                    let mut average_containment_ani = None;
+                    let mut max_containment_ani = None;
+
+                    // estimate ANI values
+                    if estimate_ani {
+                        let qani = ani_from_containment(containment_query_in_target, ksize) * 100.0;
+                        let mani = ani_from_containment(containment_target_in_query, ksize) * 100.0;
+                        query_ani = Some(qani);
+                        match_ani = Some(mani);
+                        average_containment_ani = Some((qani + mani) / 2.);
+                        max_containment_ani = Some(f64::max(qani, mani));
+                    }
+
                     results.push(MultiSearchResult {
                         query_name: query.name.clone(),
                         query_md5: query.md5sum.clone(),

--- a/src/pairwise.rs
+++ b/src/pairwise.rs
@@ -19,8 +19,9 @@ pub fn pairwise(
     siglist: String,
     threshold: f64,
     selection: &Selection,
-    output: Option<String>,
     allow_failed_sigpaths: bool,
+    estimate_ani: bool,
+    output: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Load all sigs into memory at once.
     let collection = load_collection(
@@ -64,10 +65,18 @@ pub fn pairwise(
             let jaccard = overlap / (query1_size + query2_size - overlap);
 
             // estimate ANI values
-            let query_ani = ani_from_containment(containment_q1_in_q2, ksize) * 100.0;
-            let match_ani = ani_from_containment(containment_q2_in_q1, ksize) * 100.0;
-            let average_containment_ani = (query_ani + match_ani) / 2.;
-            let max_containment_ani = f64::max(query_ani, match_ani);
+            let mut query_ani = None;
+            let mut match_ani = None;
+            let mut average_containment_ani = None;
+            let mut max_containment_ani = None;
+            if estimate_ani {
+                let qani = ani_from_containment(containment_q1_in_q2, ksize) * 100.0;
+                let mani = ani_from_containment(containment_q2_in_q1, ksize) * 100.0;
+                query_ani = Some(qani);
+                match_ani = Some(mani);
+                average_containment_ani = Some((qani + mani) / 2.);
+                max_containment_ani = Some(f64::max(qani, mani));
+            }
 
             if containment_q1_in_q2 > threshold || containment_q2_in_q1 > threshold {
                 send.send(MultiSearchResult {

--- a/src/pairwise.rs
+++ b/src/pairwise.rs
@@ -61,24 +61,24 @@ pub fn pairwise(
 
             let containment_q1_in_q2 = overlap / query1_size;
             let containment_q2_in_q1 = overlap / query2_size;
-            let max_containment = containment_q1_in_q2.max(containment_q2_in_q1);
-            let jaccard = overlap / (query1_size + query2_size - overlap);
-
-            // estimate ANI values
-            let mut query_ani = None;
-            let mut match_ani = None;
-            let mut average_containment_ani = None;
-            let mut max_containment_ani = None;
-            if estimate_ani {
-                let qani = ani_from_containment(containment_q1_in_q2, ksize) * 100.0;
-                let mani = ani_from_containment(containment_q2_in_q1, ksize) * 100.0;
-                query_ani = Some(qani);
-                match_ani = Some(mani);
-                average_containment_ani = Some((qani + mani) / 2.);
-                max_containment_ani = Some(f64::max(qani, mani));
-            }
 
             if containment_q1_in_q2 > threshold || containment_q2_in_q1 > threshold {
+                let max_containment = containment_q1_in_q2.max(containment_q2_in_q1);
+                let jaccard = overlap / (query1_size + query2_size - overlap);
+                let mut query_ani = None;
+                let mut match_ani = None;
+                let mut average_containment_ani = None;
+                let mut max_containment_ani = None;
+
+                // estimate ANI values
+                if estimate_ani {
+                    let qani = ani_from_containment(containment_q1_in_q2, ksize) * 100.0;
+                    let mani = ani_from_containment(containment_q2_in_q1, ksize) * 100.0;
+                    query_ani = Some(qani);
+                    match_ani = Some(mani);
+                    average_containment_ani = Some((qani + mani) / 2.);
+                    max_containment_ani = Some(f64::max(qani, mani));
+                }
                 send.send(MultiSearchResult {
                     query_name: query.name.clone(),
                     query_md5: query.md5sum.clone(),

--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -252,6 +252,8 @@ class Branchwater_Multisearch(CommandLinePlugin):
                        help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
         p.add_argument('-c', '--cores', default=0, type=int,
                        help='number of cores to use (default is all available)')
+        p.add_argument('-a', '--ani', action='store_true',
+                       help='estimate ANI from containment')
 
     def main(self, args):
         print_version()
@@ -269,6 +271,7 @@ class Branchwater_Multisearch(CommandLinePlugin):
                                                             args.ksize,
                                                             args.scaled,
                                                             args.moltype,
+                                                            args.ani,
                                                             args.output)
         if status == 0:
             notify(f"...multisearch is done! results in '{args.output}'")
@@ -294,6 +297,8 @@ class Branchwater_Pairwise(CommandLinePlugin):
                        help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
         p.add_argument('-c', '--cores', default=0, type=int,
                        help='number of cores to use (default is all available)')
+        p.add_argument('-a', '--ani', action='store_true',
+                       help='estimate ANI from containment')
 
     def main(self, args):
         print_version()
@@ -310,6 +315,7 @@ class Branchwater_Pairwise(CommandLinePlugin):
                                                             args.ksize,
                                                             args.scaled,
                                                             args.moltype,
+                                                            args.ani,
                                                             args.output)
         if status == 0:
             notify(f"...pairwise is done! results in '{args.output}'")

--- a/src/python/tests/test_multisearch.py
+++ b/src/python/tests/test_multisearch.py
@@ -1,4 +1,5 @@
 import os
+import csv
 import pytest
 import pandas
 import sourmash
@@ -792,3 +793,38 @@ def test_simple_hp(runtmp):
                 assert q2_ani == 98.48
                 assert avg_ani == 97.91
                 assert max_ani == 98.48
+
+
+def test_simple_below_threshold(runtmp):
+    # test basic execution!
+    query_list = runtmp.output('query.txt')
+    against_list = runtmp.output('against.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(query_list, [sig2, sig47, sig63])
+    make_file_list(against_list, [sig2, sig47, sig63])
+
+    output = runtmp.output('out.csv')
+
+    runtmp.sourmash('scripts', 'multisearch', query_list, against_list,
+                    '-o', output, '--ani', '--threshold', '0.5')
+    assert os.path.exists(output)
+
+    with open(output, 'r') as csvfile:
+        reader = csv.DictReader(csvfile)
+        rows = list(reader)
+        assert len(rows) == 3
+        for row in rows:
+            # only identical reported
+            print(row)
+            assert row['query_md5'] == row['match_md5']
+            assert float(row['containment']) == 1.0
+            assert float(row['jaccard']) == 1.0
+            assert float(row['max_containment']) == 1.0
+            assert float(row['query_ani']) == 100.0
+            assert float(row['match_ani']) == 100.0
+            assert float(row['average_containment_ani']) == 100.0
+            assert float(row['max_containment_ani']) == 100.0

--- a/src/python/tests/test_multisearch.py
+++ b/src/python/tests/test_multisearch.py
@@ -30,7 +30,7 @@ def zip_siglist(runtmp, siglist, db):
 
 @pytest.mark.parametrize("zip_query", [False, True])
 @pytest.mark.parametrize("zip_db", [False, True])
-def test_simple(runtmp, zip_query, zip_db):
+def test_simple_no_ani(runtmp, zip_query, zip_db):
     # test basic execution!
     query_list = runtmp.output('query.txt')
     against_list = runtmp.output('against.txt')
@@ -51,6 +51,76 @@ def test_simple(runtmp, zip_query, zip_db):
 
     runtmp.sourmash('scripts', 'multisearch', query_list, against_list,
                     '-o', output)
+    assert os.path.exists(output)
+
+    df = pandas.read_csv(output)
+    assert len(df) == 5
+
+    dd = df.to_dict(orient='index')
+    print(dd)
+
+    for idx, row in dd.items():
+        # identical?
+        if row['match_name'] == row['query_name']:
+            assert row['query_md5'] == row['match_md5'], row
+            assert float(row['containment'] == 1.0)
+            assert float(row['jaccard'] == 1.0)
+            assert float(row['max_containment'] == 1.0)
+            assert 'query_ani' not in row
+            assert 'match_ani' not in row
+            assert 'average_containment_ani' not in row
+            assert 'max_containment_ani' not in row
+
+        else:
+            # confirm hand-checked numbers
+            q = row['query_name'].split()[0]
+            m = row['match_name'].split()[0]
+            cont = float(row['containment'])
+            jaccard = float(row['jaccard'])
+            maxcont = float(row['max_containment'])
+            intersect_hashes = int(row['intersect_hashes'])
+
+            jaccard = round(jaccard, 4)
+            cont = round(cont, 4)
+            maxcont = round(maxcont, 4)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}")
+
+            if q == 'NC_011665.1' and m == 'NC_009661.1':
+                assert jaccard == 0.3207
+                assert cont == 0.4828
+                assert maxcont == 0.4885
+                assert intersect_hashes == 2529
+
+            if q == 'NC_009661.1' and m == 'NC_011665.1':
+                assert jaccard == 0.3207
+                assert cont == 0.4885
+                assert maxcont == 0.4885
+                assert intersect_hashes == 2529
+
+
+@pytest.mark.parametrize("zip_query", [False, True])
+@pytest.mark.parametrize("zip_db", [False, True])
+def test_simple_ani(runtmp, zip_query, zip_db):
+    # test basic execution!
+    query_list = runtmp.output('query.txt')
+    against_list = runtmp.output('against.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(query_list, [sig2, sig47, sig63])
+    make_file_list(against_list, [sig2, sig47, sig63])
+
+    output = runtmp.output('out.csv')
+
+    if zip_db:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('db.zip'))
+    if zip_query:
+        query_list = zip_siglist(runtmp, query_list, runtmp.output('query.zip'))
+
+    runtmp.sourmash('scripts', 'multisearch', query_list, against_list,
+                    '-o', output, '--ani')
     assert os.path.exists(output)
 
     df = pandas.read_csv(output)
@@ -113,7 +183,6 @@ def test_simple(runtmp, zip_query, zip_db):
                 assert q2_ani == 97.68
                 assert avg_ani == 97.7
                 assert max_ani == 97.72
-
 
 @pytest.mark.parametrize("zip_query", [False, True])
 @pytest.mark.parametrize("zip_db", [False, True])
@@ -517,7 +586,7 @@ def test_simple_prot(runtmp):
 
     runtmp.sourmash('scripts', 'multisearch', sigs, sigs,
                     '-o', output, '--moltype', 'protein',
-                    '-k', '19', '--scaled', '100')
+                    '-k', '19', '--scaled', '100', '--ani')
     assert os.path.exists(output)
 
     df = pandas.read_csv(output)
@@ -589,7 +658,7 @@ def test_simple_dayhoff(runtmp):
 
     runtmp.sourmash('scripts', 'multisearch', sigs, sigs,
                     '-o', output, '--moltype', 'dayhoff',
-                    '-k', '19', '--scaled', '100')
+                    '-k', '19', '--scaled', '100', '--ani')
     assert os.path.exists(output)
 
     df = pandas.read_csv(output)
@@ -661,7 +730,7 @@ def test_simple_hp(runtmp):
 
     runtmp.sourmash('scripts', 'multisearch', sigs, sigs,
                     '-o', output, '--moltype', 'hp',
-                    '-k', '19', '--scaled', '100')
+                    '-k', '19', '--scaled', '100', '--ani')
     assert os.path.exists(output)
 
     df = pandas.read_csv(output)

--- a/src/python/tests/test_multisearch.py
+++ b/src/python/tests/test_multisearch.py
@@ -66,6 +66,10 @@ def test_simple(runtmp, zip_query, zip_db):
             assert float(row['containment'] == 1.0)
             assert float(row['jaccard'] == 1.0)
             assert float(row['max_containment'] == 1.0)
+            assert float(row['query_ani'] == 100.0)
+            assert float(row['match_ani'] == 100.0)
+            assert float(row['average_containment_ani'] == 100.0)
+            assert float(row['max_containment_ani'] == 100.0)
 
         else:
             # confirm hand-checked numbers
@@ -75,23 +79,40 @@ def test_simple(runtmp, zip_query, zip_db):
             jaccard = float(row['jaccard'])
             maxcont = float(row['max_containment'])
             intersect_hashes = int(row['intersect_hashes'])
+            q1_ani = float(row['query_ani'])
+            q2_ani = float(row['match_ani'])
+            avg_ani = float(row['average_containment_ani'])
+            max_ani = float(row['max_containment_ani'])
+
 
             jaccard = round(jaccard, 4)
             cont = round(cont, 4)
             maxcont = round(maxcont, 4)
-            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}")
+            q1_ani = round(q1_ani, 2)
+            q2_ani = round(q2_ani, 2)
+            avg_ani = round(avg_ani, 2)
+            max_ani = round(max_ani, 2)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", f"{q1_ani:.04}", f"{q2_ani:.04}", f"{avg_ani:.04}", f"{max_ani:.04}")
 
             if q == 'NC_011665.1' and m == 'NC_009661.1':
                 assert jaccard == 0.3207
                 assert cont == 0.4828
                 assert maxcont == 0.4885
                 assert intersect_hashes == 2529
+                assert q1_ani == 97.68
+                assert q2_ani == 97.72
+                assert avg_ani == 97.7
+                assert max_ani == 97.72
 
             if q == 'NC_009661.1' and m == 'NC_011665.1':
                 assert jaccard == 0.3207
                 assert cont == 0.4885
                 assert maxcont == 0.4885
                 assert intersect_hashes == 2529
+                assert q1_ani == 97.72
+                assert q2_ani == 97.68
+                assert avg_ani == 97.7
+                assert max_ani == 97.72
 
 
 @pytest.mark.parametrize("zip_query", [False, True])
@@ -512,6 +533,10 @@ def test_simple_prot(runtmp):
             assert float(row['containment'] == 1.0)
             assert float(row['jaccard'] == 1.0)
             assert float(row['max_containment'] == 1.0)
+            assert float(row['query_ani'] == 100.0)
+            assert float(row['match_ani'] == 100.0)
+            assert float(row['average_containment_ani'] == 100.0)
+            assert float(row['max_containment_ani'] == 100.0)
 
         else:
             # confirm hand-checked numbers
@@ -521,23 +546,39 @@ def test_simple_prot(runtmp):
             jaccard = float(row['jaccard'])
             maxcont = float(row['max_containment'])
             intersect_hashes = int(row['intersect_hashes'])
+            q1_ani = float(row['query_ani'])
+            q2_ani = float(row['match_ani'])
+            avg_ani = float(row['average_containment_ani'])
+            max_ani = float(row['max_containment_ani'])
 
             jaccard = round(jaccard, 4)
             cont = round(cont, 4)
             maxcont = round(maxcont, 4)
-            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
+            q1_ani = round(q1_ani, 2)
+            q2_ani = round(q2_ani, 2)
+            avg_ani = round(avg_ani, 2)
+            max_ani = round(max_ani, 2)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes, f"{q1_ani:.04}", f"{q2_ani:.04}", f"{avg_ani:.04}", f"{max_ani:.04}")
 
             if q == 'GCA_001593925' and m == 'GCA_001593935':
                 assert jaccard == 0.0434
                 assert cont == 0.1003
                 assert maxcont == 0.1003
                 assert intersect_hashes == 342
+                assert q1_ani == 88.6
+                assert q2_ani == 87.02
+                assert avg_ani == 87.81
+                assert max_ani == 88.6
 
             if q == 'GCA_001593935' and m == 'GCA_001593925':
                 assert jaccard == 0.0434
                 assert cont == 0.0712
                 assert maxcont == 0.1003
                 assert intersect_hashes == 342
+                assert q1_ani == 87.02
+                assert q2_ani == 88.6
+                assert avg_ani == 87.81
+                assert max_ani == 88.6
 
 
 def test_simple_dayhoff(runtmp):
@@ -564,6 +605,10 @@ def test_simple_dayhoff(runtmp):
             assert float(row['containment'] == 1.0)
             assert float(row['jaccard'] == 1.0)
             assert float(row['max_containment'] == 1.0)
+            assert float(row['query_ani'] == 100.0)
+            assert float(row['match_ani'] == 100.0)
+            assert float(row['average_containment_ani'] == 100.0)
+            assert float(row['max_containment_ani'] == 100.0)
 
         else:
             # confirm hand-checked numbers
@@ -573,23 +618,39 @@ def test_simple_dayhoff(runtmp):
             jaccard = float(row['jaccard'])
             maxcont = float(row['max_containment'])
             intersect_hashes = int(row['intersect_hashes'])
+            q1_ani = float(row['query_ani'])
+            q2_ani = float(row['match_ani'])
+            avg_ani = float(row['average_containment_ani'])
+            max_ani = float(row['max_containment_ani'])
 
             jaccard = round(jaccard, 4)
             cont = round(cont, 4)
             maxcont = round(maxcont, 4)
-            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
+            q1_ani = round(q1_ani, 2)
+            q2_ani = round(q2_ani, 2)
+            avg_ani = round(avg_ani, 2)
+            max_ani = round(max_ani, 2)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes, f"{q1_ani:.04}", f"{q2_ani:.04}", f"{avg_ani:.04}", f"{max_ani:.04}")
 
             if q == 'GCA_001593925' and m == 'GCA_001593935':
                 assert jaccard == 0.1326
                 assert cont == 0.2815
                 assert maxcont == 0.2815
                 assert intersect_hashes == 930
+                assert q1_ani == 93.55
+                assert q2_ani == 91.89
+                assert avg_ani == 92.72
+                assert max_ani == 93.55
 
             if q == 'GCA_001593935' and m == 'GCA_001593925':
                 assert jaccard == 0.1326
                 assert cont == 0.2004
                 assert maxcont == 0.2815
                 assert intersect_hashes == 930
+                assert q1_ani == 91.89
+                assert q2_ani == 93.55
+                assert avg_ani == 92.72
+                assert max_ani == 93.55
 
 
 def test_simple_hp(runtmp):
@@ -616,6 +677,10 @@ def test_simple_hp(runtmp):
             assert float(row['containment'] == 1.0)
             assert float(row['jaccard'] == 1.0)
             assert float(row['max_containment'] == 1.0)
+            assert float(row['query_ani'] == 100.0)
+            assert float(row['match_ani'] == 100.0)
+            assert float(row['average_containment_ani'] == 100.0)
+            assert float(row['max_containment_ani'] == 100.0)
 
         else:
             # confirm hand-checked numbers
@@ -625,20 +690,36 @@ def test_simple_hp(runtmp):
             jaccard = float(row['jaccard'])
             maxcont = float(row['max_containment'])
             intersect_hashes = int(row['intersect_hashes'])
+            q1_ani = float(row['query_ani'])
+            q2_ani = float(row['match_ani'])
+            avg_ani = float(row['average_containment_ani'])
+            max_ani = float(row['max_containment_ani'])
 
             jaccard = round(jaccard, 4)
             cont = round(cont, 4)
             maxcont = round(maxcont, 4)
-            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
+            q1_ani = round(q1_ani, 2)
+            q2_ani = round(q2_ani, 2)
+            avg_ani = round(avg_ani, 2)
+            max_ani = round(max_ani, 2)
+            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes, f"{q1_ani:.04}", f"{q2_ani:.04}", f"{avg_ani:.04}", f"{max_ani:.04}")
 
             if q == 'GCA_001593925' and m == 'GCA_001593935':
                 assert jaccard == 0.4983
                 assert cont == 0.747
                 assert maxcont == 0.747
                 assert intersect_hashes == 1724
+                assert q1_ani == 98.48
+                assert q2_ani == 97.34
+                assert avg_ani == 97.91
+                assert max_ani == 98.48
 
             if q == 'GCA_001593935' and m == 'GCA_001593925':
                 assert jaccard == 0.4983
                 assert cont == 0.5994
                 assert maxcont == 0.747
                 assert intersect_hashes == 1724
+                assert q1_ani == 97.34
+                assert q2_ani == 98.48
+                assert avg_ani == 97.91
+                assert max_ani == 98.48

--- a/src/python/tests/test_pairwise.py
+++ b/src/python/tests/test_pairwise.py
@@ -55,38 +55,36 @@ def test_simple(runtmp, zip_query):
     print(dd)
 
     for idx, row in dd.items():
-        # identical?
-        if row['match_name'] == row['query_name']:
-            assert row['query_md5'] == row['match_md5'], row
-            assert float(row['containment'] == 1.0)
-            assert float(row['jaccard'] == 1.0)
-            assert float(row['max_containment'] == 1.0)
+        # confirm hand-checked numbers
+        q = row['query_name'].split()[0]
+        m = row['match_name'].split()[0]
+        cont = float(row['containment'])
+        jaccard = float(row['jaccard'])
+        maxcont = float(row['max_containment'])
+        intersect_hashes = int(row['intersect_hashes'])
+        q1_ani = float(row['query_ani'])
+        q2_ani = float(row['match_ani'])
+        avg_ani = float(row['average_containment_ani'])
+        max_ani = float(row['max_containment_ani'])
 
-        else:
-            # confirm hand-checked numbers
-            q = row['query_name'].split()[0]
-            m = row['match_name'].split()[0]
-            cont = float(row['containment'])
-            jaccard = float(row['jaccard'])
-            maxcont = float(row['max_containment'])
-            intersect_hashes = int(row['intersect_hashes'])
+        jaccard = round(jaccard, 4)
+        cont = round(cont, 4)
+        maxcont = round(maxcont, 4)
+        q1_ani = round(q1_ani, 2)
+        q2_ani = round(q2_ani, 2)
+        avg_ani = round(avg_ani, 2)
+        max_ani = round(max_ani, 2)
+        print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", f"{q1_ani:.04}", f"{q2_ani:.04}", f"{avg_ani:.04}", f"{max_ani:.04}")
 
-            jaccard = round(jaccard, 4)
-            cont = round(cont, 4)
-            maxcont = round(maxcont, 4)
-            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}")
-
-            if q == 'NC_011665.1' and m == 'NC_009661.1':
-                assert jaccard == 0.3207
-                assert cont == 0.4828
-                assert maxcont == 0.4885
-                assert intersect_hashes == 2529
-
-            if q == 'NC_009661.1' and m == 'NC_011665.1':
-                assert jaccard == 0.3207
-                assert cont == 0.4885
-                assert maxcont == 0.4885
-                assert intersect_hashes == 2529
+        if q == 'NC_011665.1' and m == 'NC_009661.1':
+            assert jaccard == 0.3207
+            assert cont == 0.4828
+            assert maxcont == 0.4885
+            assert intersect_hashes == 2529
+            assert q1_ani == 97.68
+            assert q2_ani == 97.72
+            assert avg_ani == 97.7
+            assert max_ani == 97.72
 
 
 @pytest.mark.parametrize("zip_query", [False, True])
@@ -349,38 +347,36 @@ def test_simple_prot(runtmp):
     print(dd)
 
     for idx, row in dd.items():
-        # identical?
-        if row['match_name'] == row['query_name']:
-            assert row['query_md5'] == row['match_md5'], row
-            assert float(row['containment'] == 1.0)
-            assert float(row['jaccard'] == 1.0)
-            assert float(row['max_containment'] == 1.0)
+        # confirm hand-checked numbers
+        q = row['query_name'].split()[0]
+        m = row['match_name'].split()[0]
+        cont = float(row['containment'])
+        jaccard = float(row['jaccard'])
+        maxcont = float(row['max_containment'])
+        intersect_hashes = int(row['intersect_hashes'])
+        q1_ani = float(row['query_ani'])
+        q2_ani = float(row['match_ani'])
+        avg_ani = float(row['average_containment_ani'])
+        max_ani = float(row['max_containment_ani'])
 
-        else:
-            # confirm hand-checked numbers
-            q = row['query_name'].split()[0]
-            m = row['match_name'].split()[0]
-            cont = float(row['containment'])
-            jaccard = float(row['jaccard'])
-            maxcont = float(row['max_containment'])
-            intersect_hashes = int(row['intersect_hashes'])
+        jaccard = round(jaccard, 4)
+        cont = round(cont, 4)
+        maxcont = round(maxcont, 4)
+        q1_ani = round(q1_ani, 2)
+        q2_ani = round(q2_ani, 2)
+        avg_ani = round(avg_ani, 2)
+        max_ani = round(max_ani, 2)
+        print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes, f"{q1_ani:.04}", f"{q2_ani:.04}", f"{avg_ani:.04}", f"{max_ani:.04}")
 
-            jaccard = round(jaccard, 4)
-            cont = round(cont, 4)
-            maxcont = round(maxcont, 4)
-            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
-
-            if q == 'GCA_001593925' and m == 'GCA_001593935':
-                assert jaccard == 0.0434
-                assert cont == 0.1003
-                assert maxcont == 0.1003
-                assert intersect_hashes == 342
-
-            if q == 'GCA_001593935' and m == 'GCA_001593925':
-                assert jaccard == 0.0434
-                assert cont == 0.0712
-                assert maxcont == 0.1003
-                assert intersect_hashes == 342
+        if q == 'GCA_001593925' and m == 'GCA_001593935':
+            assert jaccard == 0.0434
+            assert cont == 0.1003
+            assert maxcont == 0.1003
+            assert intersect_hashes == 342
+            assert q1_ani == 88.60
+            assert q2_ani == 87.02
+            assert avg_ani == 87.81
+            assert max_ani == 88.6
 
 
 def test_simple_dayhoff(runtmp):
@@ -401,38 +397,36 @@ def test_simple_dayhoff(runtmp):
     print(dd)
 
     for idx, row in dd.items():
-        # identical?
-        if row['match_name'] == row['query_name']:
-            assert row['query_md5'] == row['match_md5'], row
-            assert float(row['containment'] == 1.0)
-            assert float(row['jaccard'] == 1.0)
-            assert float(row['max_containment'] == 1.0)
+        # confirm hand-checked numbers
+        q = row['query_name'].split()[0]
+        m = row['match_name'].split()[0]
+        cont = float(row['containment'])
+        jaccard = float(row['jaccard'])
+        maxcont = float(row['max_containment'])
+        intersect_hashes = int(row['intersect_hashes'])
+        q1_ani = float(row['query_ani'])
+        q2_ani = float(row['match_ani'])
+        avg_ani = float(row['average_containment_ani'])
+        max_ani = float(row['max_containment_ani'])
 
-        else:
-            # confirm hand-checked numbers
-            q = row['query_name'].split()[0]
-            m = row['match_name'].split()[0]
-            cont = float(row['containment'])
-            jaccard = float(row['jaccard'])
-            maxcont = float(row['max_containment'])
-            intersect_hashes = int(row['intersect_hashes'])
+        jaccard = round(jaccard, 4)
+        cont = round(cont, 4)
+        maxcont = round(maxcont, 4)
+        q1_ani = round(q1_ani, 2)
+        q2_ani = round(q2_ani, 2)
+        avg_ani = round(avg_ani, 2)
+        max_ani = round(max_ani, 2)
+        print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes, f"{q1_ani:.04}", f"{q2_ani:.04}", f"{avg_ani:.04}", f"{max_ani:.04}")
 
-            jaccard = round(jaccard, 4)
-            cont = round(cont, 4)
-            maxcont = round(maxcont, 4)
-            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
-
-            if q == 'GCA_001593925' and m == 'GCA_001593935':
-                assert jaccard == 0.1326
-                assert cont == 0.2815
-                assert maxcont == 0.2815
-                assert intersect_hashes == 930
-
-            if q == 'GCA_001593935' and m == 'GCA_001593925':
-                assert jaccard == 0.1326
-                assert cont == 0.2004
-                assert maxcont == 0.2815
-                assert intersect_hashes == 930
+        if q == 'GCA_001593925' and m == 'GCA_001593935':
+            assert jaccard == 0.1326
+            assert cont == 0.2815
+            assert maxcont == 0.2815
+            assert intersect_hashes == 930
+            assert q1_ani == 93.55
+            assert q2_ani == 91.89
+            assert avg_ani == 92.72
+            assert max_ani == 93.55
 
 
 def test_simple_hp(runtmp):
@@ -453,35 +447,33 @@ def test_simple_hp(runtmp):
     print(dd)
 
     for idx, row in dd.items():
-        # identical?
-        if row['match_name'] == row['query_name']:
-            assert row['query_md5'] == row['match_md5'], row
-            assert float(row['containment'] == 1.0)
-            assert float(row['jaccard'] == 1.0)
-            assert float(row['max_containment'] == 1.0)
+        # confirm hand-checked numbers
+        q = row['query_name'].split()[0]
+        m = row['match_name'].split()[0]
+        cont = float(row['containment'])
+        jaccard = float(row['jaccard'])
+        maxcont = float(row['max_containment'])
+        intersect_hashes = int(row['intersect_hashes'])
+        q1_ani = float(row['query_ani'])
+        q2_ani = float(row['match_ani'])
+        avg_ani = float(row['average_containment_ani'])
+        max_ani = float(row['max_containment_ani'])
 
-        else:
-            # confirm hand-checked numbers
-            q = row['query_name'].split()[0]
-            m = row['match_name'].split()[0]
-            cont = float(row['containment'])
-            jaccard = float(row['jaccard'])
-            maxcont = float(row['max_containment'])
-            intersect_hashes = int(row['intersect_hashes'])
+        jaccard = round(jaccard, 4)
+        cont = round(cont, 4)
+        maxcont = round(maxcont, 4)
+        q1_ani = round(q1_ani, 2)
+        q2_ani = round(q2_ani, 2)
+        avg_ani = round(avg_ani, 2)
+        max_ani = round(max_ani, 2)
+        print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes, f"{q1_ani:.04}", f"{q2_ani:.04}", f"{avg_ani:.04}", f"{max_ani:.04}")
 
-            jaccard = round(jaccard, 4)
-            cont = round(cont, 4)
-            maxcont = round(maxcont, 4)
-            print(q, m, f"{jaccard:.04}", f"{cont:.04}", f"{maxcont:.04}", intersect_hashes)
-
-            if q == 'GCA_001593925' and m == 'GCA_001593935':
-                assert jaccard == 0.4983
-                assert cont == 0.747
-                assert maxcont == 0.747
-                assert intersect_hashes == 1724
-
-            if q == 'GCA_001593935' and m == 'GCA_001593925':
-                assert jaccard == 0.4983
-                assert cont == 0.5994
-                assert maxcont == 0.747
-                assert intersect_hashes == 1724
+        if q == 'GCA_001593925' and m == 'GCA_001593935':
+            assert jaccard == 0.4983
+            assert cont == 0.747
+            assert maxcont == 0.747
+            assert intersect_hashes == 1724
+            assert q1_ani == 98.48
+            assert q2_ani == 97.34
+            assert avg_ani == 97.91
+            assert max_ani == 98.48

--- a/src/python/tests/test_pairwise.py
+++ b/src/python/tests/test_pairwise.py
@@ -1,4 +1,5 @@
 import os
+import csv
 import pytest
 import pandas
 import sourmash
@@ -529,3 +530,27 @@ def test_simple_hp_ani(runtmp):
             assert q2_ani == 97.34
             assert avg_ani == 97.91
             assert max_ani == 98.48
+
+
+def test_simple_below_threshold(runtmp):
+    # test basic execution!
+    query_list = runtmp.output('query.txt')
+    against_list = runtmp.output('against.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    make_file_list(query_list, [sig2, sig47, sig63])
+
+    output = runtmp.output('out.csv')
+
+    runtmp.sourmash('scripts', 'pairwise', query_list,
+                    '-o', output, '--ani', '--threshold', '0.5')
+    assert os.path.exists(output)
+
+    with open(output, 'r') as csvfile:
+        reader = csv.reader(csvfile)
+        rows = list(reader)
+        print(rows)
+        assert len(rows) == 0

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use camino::Utf8Path as Path;
 use camino::Utf8PathBuf as PathBuf;
 use csv::Writer;
 use serde::ser::Serializer;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::BinaryHeap;
 use std::fs::{create_dir_all, File};
@@ -716,7 +716,7 @@ pub struct BranchwaterGatherResult {
     pub intersect_bp: usize,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct MultiSearchResult {
     pub query_name: String,
     pub query_md5: String,
@@ -726,6 +726,10 @@ pub struct MultiSearchResult {
     pub max_containment: f64,
     pub jaccard: f64,
     pub intersect_hashes: f64,
+    pub query_ani: f64,
+    pub match_ani: f64,
+    pub average_containment_ani: f64,
+    pub max_containment_ani: f64,
 }
 
 #[derive(Serialize)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -726,10 +726,15 @@ pub struct MultiSearchResult {
     pub max_containment: f64,
     pub jaccard: f64,
     pub intersect_hashes: f64,
-    pub query_ani: f64,
-    pub match_ani: f64,
-    pub average_containment_ani: f64,
-    pub max_containment_ani: f64,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query_ani: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_ani: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub average_containment_ani: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_containment_ani: Option<f64>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Adds ANI columns to pairwise and multisearch output, building off of @mr-eyes's ANI translations (#188) which got streamlined + added into sourmash core in https://github.com/sourmash-bio/sourmash/pull/2943

Split from #234 to make things more concise/simpler.

## benchmark summary

## 12k ICTV viral genomes, scaled=200

79.8m comparisons

| version | experiment | time |
| -------- | -------- | -------- |
| PR | no ANI     | 21s     | 
| PR | with ANI     | 20s     |
| v0.9.0 | no ANI | 21s |


## 12k ICTV viral genomes, scaled=10

79.8m comparisons

| version | experiment | time |
| -------- | -------- | -------- |
| PR | no ANI     | 14m 0s     | 
| PR | with ANI     | 14m 6s     | 
| main branch (~v0.9.0) | no ANI | 14m 47s |
