### PR TITLE
MRG: PR to release v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "sourmash_plugin_branchwater"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash_plugin_branchwater"
-version = "0.9.1-dev"
+version = "0.9.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
release notes - [edit](https://hackmd.io/fdjNJ7BxQ32v_2Gel9Lp3Q?both)

# release notes sourmash_plugin_branchwater v0.9.1

Updates and features:

* Add graph-based clustering with `cluster` (#234)
* Enable `singleton` sketching, facilitate `reads`-based sketching in `manysketch` (#184)
* Use updated core `GatherResult` to enable full results from `fastmultigather`(#205)
* Add ANI output to `pairwise`, `multisearch` (#236)
* Use `core` manifest utils (#217)
* Fix clippy warnings from `manysketch` improvements (#251)

Dependency updates:

* Bump conda-incubator/setup-miniconda from 3.0.1 to 3.0.2 (#242)
* Bump env_logger from 0.10.2 to 0.11.2 (#240)
* Bump pyo3 from 0.20.2 to 0.20.3 (#241)
* bump to v0.9.1-dev (#230)
* Bump anyhow from 1.0.79 to 1.0.80 (#227)
* Bump assert_cmd from 2.0.13 to 2.0.14 (#229)