### PR TITLE
MRG: fix clippy warnings from `manysketch` improvements

### DIFF
--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -165,7 +165,10 @@ pub fn manysketch(
 
     let send_result = fileinfo
         .par_iter()
-        .filter_map(|(name, filenames, moltype)| {
+        .filter_map(|fastadata| {
+            let name = &fastadata.name;
+            let filenames = &fastadata.paths;
+            let moltype = &fastadata.input_type;
             let mut allsigs = Vec::new();
             // build sig templates for these sketches from params, check if there are sigs to build
             let sig_templates = build_siginfo(&params_vec, moltype);

--- a/src/mastiff_manygather.rs
+++ b/src/mastiff_manygather.rs
@@ -99,7 +99,7 @@ pub fn mastiff_manygather(
                                     ksize: ksize as usize,
                                     moltype: query_mh.hash_function().to_string(),
                                     scaled: query_mh.scaled() as usize,
-                                    query_n_hashes: query_mh.size() as usize,
+                                    query_n_hashes: query_mh.size(),
                                     query_abundance: query_mh.track_abundance(),
                                     query_containment_ani: match_.query_containment_ani(),
                                     match_containment_ani: match_.match_containment_ani(),


### PR DESCRIPTION
Forgot to consult our clippy overlord for that PR :). 

Here, we use FastaData struct to reduce return complexity from fasta csv reading.