### PR TITLE
WIP: add Ctrl-C interrupt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+dependencies = [
+ "nix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +963,17 @@ dependencies = [
  "thiserror",
  "xz2",
  "zstd",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1730,6 +1751,7 @@ dependencies = [
  "assert_matches",
  "camino",
  "csv",
+ "ctrlc",
  "env_logger",
  "log",
  "needletail",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ needletail = "0.5.1"
 csv = "1.3.0"
 camino = "1.1.6"
 rustworkx-core = "0.14.0"
+ctrlc = "3.4.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -64,64 +64,76 @@ pub fn manysearch(
     let skipped_paths = AtomicUsize::new(0);
     let failed_paths = AtomicUsize::new(0);
 
-    against_collection.par_iter().for_each(|(_idx, record)| {
-        let manager_clone = manager_shared.clone();
-        let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
-        if i % 1000 == 0 {
-            eprintln!("Processed {} search sigs", i);
-        }
+    against_collection
+        .par_iter()
+        .filter_map(|(_idx, record)| {
+            let i = processed_sigs.fetch_add(1, atomic::Ordering::SeqCst);
+            if i % 1000 == 0 {
+                eprintln!("Processed {} search sigs", i);
+            }
 
-        // against downsampling happens here
-        match against_collection.sig_from_record(record) {
-            Ok(against_sig) => {
-                if let Some(against_mh) = against_sig.minhash() {
-                    for query in query_sketchlist.iter() {
-                        if manager_clone
-                            .lock()
-                            .unwrap()
-                            .interrupted
-                            .load(Ordering::SeqCst)
-                        {
-                            // If interrupted, simply exit the closure
-                            return;
-                        }
-                        let overlap = query.minhash.count_common(against_mh, false).unwrap() as f64;
-                        let query_size = query.minhash.size() as f64;
-                        let target_size = against_mh.size() as f64;
-                        let containment_query_in_target = overlap / query_size;
-                        let containment_target_in_query = overlap / target_size;
-                        let jaccard = overlap / (target_size + query_size - overlap);
-                        let max_containment =
-                            containment_query_in_target.max(containment_target_in_query);
+            let mut results = vec![];
 
-                        if containment_query_in_target > threshold {
-                            let search_result = SearchResult {
-                                query_name: query.name.clone(),
-                                query_md5: query.md5sum.clone(),
-                                match_name: against_sig.name(),
-                                containment: containment_query_in_target,
-                                intersect_hashes: overlap as usize,
-                                match_md5: Some(against_sig.md5sum()),
-                                jaccard: Some(jaccard),
-                                max_containment: Some(max_containment),
-                            };
-                            manager_clone.lock().unwrap().send(search_result);
+            // against downsampling happens here
+            match against_collection.sig_from_record(record) {
+                Ok(against_sig) => {
+                    if let Some(against_mh) = against_sig.minhash() {
+                        for query in query_sketchlist.iter() {
+                            if manager_shared
+                                .lock()
+                                .unwrap()
+                                .interrupted
+                                .load(Ordering::SeqCst)
+                            {
+                                return None; // Early exit if interrupted
+                            }
+                            let overlap =
+                                query.minhash.count_common(against_mh, false).unwrap() as f64;
+                            let query_size = query.minhash.size() as f64;
+                            let target_size = against_mh.size() as f64;
+                            let containment_query_in_target = overlap / query_size;
+                            let containment_in_target = overlap / target_size;
+                            let max_containment =
+                                containment_query_in_target.max(containment_in_target);
+                            let jaccard = overlap / (target_size + query_size - overlap);
+
+                            if containment_query_in_target > threshold {
+                                results.push(SearchResult {
+                                    query_name: query.name.clone(),
+                                    query_md5: query.md5sum.clone(),
+                                    match_name: against_sig.name(),
+                                    containment: containment_query_in_target,
+                                    intersect_hashes: overlap as usize,
+                                    match_md5: Some(against_sig.md5sum()),
+                                    jaccard: Some(jaccard),
+                                    max_containment: Some(max_containment),
+                                });
+                            }
                         }
+                    } else {
+                        eprintln!(
+                            "WARNING: no compatible sketches in path '{}'",
+                            record.internal_location()
+                        );
+                        let _ = skipped_paths.fetch_add(1, atomic::Ordering::SeqCst);
                     }
-                } else {
+                }
+                Err(err) => {
+                    eprintln!("Sketch loading error: {}", err);
                     eprintln!(
                         "WARNING: no compatible sketches in path '{}'",
                         record.internal_location()
                     );
-                    skipped_paths.fetch_add(1, Ordering::SeqCst);
+                    let _ = skipped_paths.fetch_add(1, atomic::Ordering::SeqCst);
                 }
             }
-            Err(err) => {
-                eprintln!("Sketch loading error: {}", err);
-                skipped_paths.fetch_add(1, Ordering::SeqCst);
-            }
-        }
-    });
+
+            Some(results)
+        })
+        .flatten()
+        .try_for_each_with(manager_shared.clone(), |manager, result| {
+            manager.lock().unwrap().send(result)
+        })?;
 
     // do some cleanup and error handling -
     manager_shared.lock().unwrap().perform_cleanup();

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -6,9 +6,13 @@
 use anyhow::Result;
 use rayon::prelude::*;
 use std::sync::atomic;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
 
-use crate::utils::{csvwriter_thread, load_collection, load_sketches, ReportType, SearchResult};
+use crate::utils::{
+    csvwriter_thread, load_collection, load_sketches, ReportType, SearchResult, ThreadManager,
+};
 use sourmash::selection::Selection;
 use sourmash::signature::SigsTrait;
 
@@ -44,6 +48,12 @@ pub fn manysearch(
     // & spawn a thread that is dedicated to printing to a buffered output
     let thrd = csvwriter_thread(recv, output);
 
+    // set up manager to allow for ctrl-c handling
+    let manager = ThreadManager::new(send, thrd);
+
+    // Wrap ThreadManager in Arc<Mutex> for safe sharing across threads
+    let manager_shared = Arc::new(Mutex::new(manager));
+
     //
     // Main loop: iterate (in parallel) over all search signature paths,
     // loading them individually and searching them. Stuff results into
@@ -54,75 +64,67 @@ pub fn manysearch(
     let skipped_paths = AtomicUsize::new(0);
     let failed_paths = AtomicUsize::new(0);
 
-    let send = against_collection
-        .par_iter()
-        .filter_map(|(_idx, record)| {
-            let i = processed_sigs.fetch_add(1, atomic::Ordering::SeqCst);
-            if i % 1000 == 0 {
-                eprintln!("Processed {} search sigs", i);
-            }
+    against_collection.par_iter().for_each(|(_idx, record)| {
+        let manager_clone = manager_shared.clone();
+        let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
+        if i % 1000 == 0 {
+            eprintln!("Processed {} search sigs", i);
+        }
 
-            let mut results = vec![];
-
-            // against downsampling happens here
-            match against_collection.sig_from_record(record) {
-                Ok(against_sig) => {
-                    if let Some(against_mh) = against_sig.minhash() {
-                        for query in query_sketchlist.iter() {
-                            let overlap =
-                                query.minhash.count_common(against_mh, false).unwrap() as f64;
-                            let query_size = query.minhash.size() as f64;
-                            let target_size = against_mh.size() as f64;
-                            let containment_query_in_target = overlap / query_size;
-                            let containment_in_target = overlap / target_size;
-                            let max_containment =
-                                containment_query_in_target.max(containment_in_target);
-                            let jaccard = overlap / (target_size + query_size - overlap);
-
-                            if containment_query_in_target > threshold {
-                                results.push(SearchResult {
-                                    query_name: query.name.clone(),
-                                    query_md5: query.md5sum.clone(),
-                                    match_name: against_sig.name(),
-                                    containment: containment_query_in_target,
-                                    intersect_hashes: overlap as usize,
-                                    match_md5: Some(against_sig.md5sum()),
-                                    jaccard: Some(jaccard),
-                                    max_containment: Some(max_containment),
-                                });
-                            }
+        // against downsampling happens here
+        match against_collection.sig_from_record(record) {
+            Ok(against_sig) => {
+                if let Some(against_mh) = against_sig.minhash() {
+                    for query in query_sketchlist.iter() {
+                        if manager_clone
+                            .lock()
+                            .unwrap()
+                            .interrupted
+                            .load(Ordering::SeqCst)
+                        {
+                            // If interrupted, simply exit the closure
+                            return;
                         }
-                    } else {
-                        eprintln!(
-                            "WARNING: no compatible sketches in path '{}'",
-                            record.internal_location()
-                        );
-                        let _ = skipped_paths.fetch_add(1, atomic::Ordering::SeqCst);
+                        let overlap = query.minhash.count_common(against_mh, false).unwrap() as f64;
+                        let query_size = query.minhash.size() as f64;
+                        let target_size = against_mh.size() as f64;
+                        let containment_query_in_target = overlap / query_size;
+                        let containment_target_in_query = overlap / target_size;
+                        let jaccard = overlap / (target_size + query_size - overlap);
+                        let max_containment =
+                            containment_query_in_target.max(containment_target_in_query);
+
+                        if containment_query_in_target > threshold {
+                            let search_result = SearchResult {
+                                query_name: query.name.clone(),
+                                query_md5: query.md5sum.clone(),
+                                match_name: against_sig.name(),
+                                containment: containment_query_in_target,
+                                intersect_hashes: overlap as usize,
+                                match_md5: Some(against_sig.md5sum()),
+                                jaccard: Some(jaccard),
+                                max_containment: Some(max_containment),
+                            };
+                            manager_clone.lock().unwrap().send(search_result);
+                        }
                     }
-                }
-                Err(err) => {
-                    eprintln!("Sketch loading error: {}", err);
+                } else {
                     eprintln!(
                         "WARNING: no compatible sketches in path '{}'",
                         record.internal_location()
                     );
-                    let _ = skipped_paths.fetch_add(1, atomic::Ordering::SeqCst);
+                    skipped_paths.fetch_add(1, Ordering::SeqCst);
                 }
             }
-
-            Some(results)
-        })
-        .flatten()
-        .try_for_each_with(send, |s, m| s.send(m));
+            Err(err) => {
+                eprintln!("Sketch loading error: {}", err);
+                skipped_paths.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    });
 
     // do some cleanup and error handling -
-    if let Err(e) = send {
-        eprintln!("Unable to send internal data: {:?}", e);
-    }
-
-    if let Err(e) = thrd.join() {
-        eprintln!("Unable to join internal thread: {:?}", e);
-    }
+    manager_shared.lock().unwrap().perform_cleanup();
 
     // done!
     let i: usize = processed_sigs.fetch_max(0, atomic::Ordering::SeqCst);

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -85,6 +85,7 @@ pub fn manysearch(
                                 .interrupted
                                 .load(Ordering::SeqCst)
                             {
+                                println!("Ctrl-C received, signaling shutdown...");
                                 return None; // Early exit if interrupted
                             }
                             let overlap =

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -88,7 +88,7 @@ pub fn manysearch(
                                 return None; // Early exit if interrupted
                             }
                             let overlap =
-                                query.minhash.count_common(against_mh, false).unwrap() as f64;
+                                query.minhash.count_common(against_mh, true).unwrap() as f64;
                             let query_size = query.minhash.size() as f64;
                             let target_size = against_mh.size() as f64;
                             let containment_query_in_target = overlap / query_size;

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -271,7 +271,7 @@ pub fn manysketch(
                 .unwrap()
                 .send(ZipMessage::SignatureData(filled_sigs))
                 .map_err(|e| anyhow!(e))
-        });
+        })?;
 
     // After the parallel work, send the WriteManifest message
     manager_shared

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -224,6 +224,7 @@ pub fn manysketch(
                         .interrupted
                         .load(Ordering::SeqCst)
                     {
+                        println!("Ctrl-C received, signaling shutdown...");
                         return None; // Early exit if interrupted
                     }
                     match record_result {

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -2,13 +2,15 @@
 use anyhow::{anyhow, Result};
 use rayon::prelude::*;
 
-use crate::utils::{load_fasta_fromfile, sigwriter, Params, ZipMessage};
+use crate::utils::{load_fasta_fromfile, sigwriter, Params, ThreadManager, ZipMessage};
 use camino::Utf8Path as Path;
 use needletail::parse_fastx_file;
 use sourmash::cmd::ComputeParameters;
 use sourmash::signature::Signature;
 use std::sync::atomic;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
 
 fn parse_params_str(params_strs: String) -> Result<Vec<Params>, String> {
     let mut unique_params: std::collections::HashSet<Params> = std::collections::HashSet::new();
@@ -139,11 +141,16 @@ pub fn manysketch(
 
     // set up a multi-producer, single-consumer channel that receives Signature
     let (send, recv) = std::sync::mpsc::sync_channel::<ZipMessage>(rayon::current_num_threads());
-    // need to use Arc so we can write the manifest after all sigs have written
-    let send = std::sync::Arc::new(send);
 
     // & spawn a thread that is dedicated to printing to a buffered output
     let thrd = sigwriter(recv, output);
+
+    // need to use Arc so we can write the manifest after all sigs have written
+    // set up manager to allow for ctrl-c handling
+    let manager = ThreadManager::new(send, thrd);
+
+    // Wrap ThreadManager in Arc<Mutex> for safe sharing across threads
+    let manager_shared = Arc::new(Mutex::new(manager));
 
     // parse param string into params_vec, print error if fail
     let param_result = parse_params_str(param_str);
@@ -163,7 +170,7 @@ pub fn manysketch(
     // set reporting threshold at every 5% or every 1 fasta, whichever is larger)
     let reporting_threshold = std::cmp::max(n_fastas / 20, 1);
 
-    let send_result = fileinfo
+    fileinfo
         .par_iter()
         .filter_map(|fastadata| {
             let name = &fastadata.name;
@@ -211,6 +218,14 @@ pub fn manysketch(
 
                 // parse fasta and add to signature
                 while let Some(record_result) = reader.next() {
+                    if manager_shared
+                        .lock()
+                        .unwrap()
+                        .interrupted
+                        .load(Ordering::SeqCst)
+                    {
+                        return None; // Early exit if interrupted
+                    }
                     match record_result {
                         Ok(record) => {
                             // do we need to normalize to make sure all the bases are consistently capitalized?
@@ -250,35 +265,22 @@ pub fn manysketch(
             }
             Some(allsigs)
         })
-        .try_for_each_with(
-            send.clone(),
-            |s: &mut std::sync::Arc<std::sync::mpsc::SyncSender<ZipMessage>>, filled_sigs| {
-                if let Err(e) = s.send(ZipMessage::SignatureData(filled_sigs)) {
-                    Err(format!("Unable to send internal data: {:?}", e))
-                } else {
-                    Ok(())
-                }
-            },
-        );
+        .try_for_each_with(manager_shared.clone(), |manager, filled_sigs| {
+            manager
+                .lock()
+                .unwrap()
+                .send(ZipMessage::SignatureData(filled_sigs))
+                .map_err(|e| anyhow!(e))
+        });
 
     // After the parallel work, send the WriteManifest message
-    std::sync::Arc::try_unwrap(send)
+    manager_shared
+        .lock()
         .unwrap()
-        .send(ZipMessage::WriteManifest)
-        .unwrap();
+        .send(ZipMessage::WriteManifest)?;
 
     // do some cleanup and error handling -
-    if let Err(e) = send_result {
-        eprintln!("Error during parallel processing: {}", e);
-    }
-
-    // join the writer thread
-    if let Err(e) = thrd
-        .join()
-        .unwrap_or_else(|e| Err(anyhow!("Thread panicked: {:?}", e)))
-    {
-        eprintln!("Error in sigwriter thread: {:?}", e);
-    }
+    manager_shared.lock().unwrap().perform_cleanup();
 
     // done!
     let i: usize = processed_fastas.load(atomic::Ordering::SeqCst);

--- a/src/mastiff_manygather.rs
+++ b/src/mastiff_manygather.rs
@@ -71,6 +71,7 @@ pub fn mastiff_manygather(
                 .interrupted
                 .load(Ordering::SeqCst)
             {
+                println!("Ctrl-C received, signaling shutdown...");
                 return None; // Early exit if interrupted
             }
 

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -74,6 +74,7 @@ pub fn mastiff_manysearch(
                 .interrupted
                 .load(Ordering::SeqCst)
             {
+                println!("Ctrl-C received, signaling shutdown...");
                 return None; // Early exit if interrupted
             }
             let mut results = vec![];

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -3,14 +3,12 @@ use anyhow::Result;
 use camino::Utf8PathBuf as PathBuf;
 use rayon::prelude::*;
 use std::sync::atomic;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use sourmash::ani_utils::ani_from_containment;
 use sourmash::index::revindex::{RevIndex, RevIndexOps};
 use sourmash::selection::Selection;
 use sourmash::signature::SigsTrait;
-use std::sync::atomic;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -6,10 +6,13 @@ use sourmash::index::revindex::{RevIndex, RevIndexOps};
 use sourmash::selection::Selection;
 use sourmash::signature::SigsTrait;
 use std::sync::atomic;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use crate::utils::{
     csvwriter_thread, is_revindex_database, load_collection, ReportType, SearchResult,
+    ThreadManager,
 };
 
 pub fn mastiff_manysearch(
@@ -42,6 +45,12 @@ pub fn mastiff_manysearch(
     // & spawn a thread that is dedicated to printing to a buffered output
     let thrd = csvwriter_thread(recv, output);
 
+    // set up manager to allow for ctrl-c handling
+    let manager = ThreadManager::new(send, thrd);
+
+    // Wrap ThreadManager in Arc<Mutex> for safe sharing across threads
+    let manager_shared = Arc::new(Mutex::new(manager));
+
     //
     // Main loop: iterate (in parallel) over all search signature paths,
     // loading them individually and searching them. Stuff results into
@@ -52,14 +61,21 @@ pub fn mastiff_manysearch(
     let skipped_paths = AtomicUsize::new(0);
     let failed_paths = AtomicUsize::new(0);
 
-    let send_result = query_collection
+    query_collection
         .par_iter()
         .filter_map(|(_idx, record)| {
             let i = processed_sigs.fetch_add(1, atomic::Ordering::SeqCst);
             if i % 1000 == 0 {
                 eprintln!("Processed {} search sigs", i);
             }
-
+            if manager_shared
+                .lock()
+                .unwrap()
+                .interrupted
+                .load(Ordering::SeqCst)
+            {
+                return None; // Early exit if interrupted
+            }
             let mut results = vec![];
             // query downsample happens here
             match query_collection.sig_from_record(record) {
@@ -111,23 +127,12 @@ pub fn mastiff_manysearch(
             }
         })
         .flatten()
-        .try_for_each_with(send, |s, results| {
-            if let Err(e) = s.send(results) {
-                Err(format!("Unable to send internal data: {:?}", e))
-            } else {
-                Ok(())
-            }
-        });
+        .try_for_each_with(manager_shared.clone(), |manager, result| {
+            manager.lock().unwrap().send(result)
+        })?;
 
     // do some cleanup and error handling -
-    if let Err(e) = send_result {
-        eprintln!("Error during parallel processing: {}", e);
-    }
-
-    // join the writer thread
-    if let Err(e) = thrd.join() {
-        eprintln!("Unable to join internal thread: {:?}", e);
-    }
+    manager_shared.lock().unwrap().perform_cleanup();
 
     // done!
     let i: usize = processed_sigs.fetch_max(0, atomic::Ordering::SeqCst);

--- a/src/multisearch.rs
+++ b/src/multisearch.rs
@@ -4,10 +4,12 @@ use rayon::prelude::*;
 use sourmash::selection::Selection;
 use sourmash::signature::SigsTrait;
 use std::sync::atomic;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use crate::utils::{
-    csvwriter_thread, load_collection, load_sketches, MultiSearchResult, ReportType,
+    csvwriter_thread, load_collection, load_sketches, MultiSearchResult, ReportType, ThreadManager,
 };
 use sourmash::ani_utils::ani_from_containment;
 
@@ -51,6 +53,11 @@ pub fn multisearch(
     // // & spawn a thread that is dedicated to printing to a buffered output
     let thrd = csvwriter_thread(recv, output);
 
+    // set up manager to allow for ctrl-c handling
+    let manager = ThreadManager::new(send, thrd);
+
+    // Wrap ThreadManager in Arc<Mutex> for safe sharing across threads
+    let manager_shared = Arc::new(Mutex::new(manager));
     //
     // Main loop: iterate (in parallel) over all search signature paths,
     // loading them individually and searching them. Stuff results into
@@ -60,12 +67,21 @@ pub fn multisearch(
     let processed_cmp = AtomicUsize::new(0);
     let ksize = selection.ksize().unwrap() as f64;
 
-    let send = against
+    against
         .par_iter()
         .filter_map(|against| {
+            // let manager_clone = manager_shared.clone();
             let mut results = vec![];
             // search for matches & save containment.
             for query in queries.iter() {
+                if manager_shared
+                    .lock()
+                    .unwrap()
+                    .interrupted
+                    .load(Ordering::SeqCst)
+                {
+                    return None; // Early exit if interrupted
+                }
                 let i = processed_cmp.fetch_add(1, atomic::Ordering::SeqCst);
                 if i % 100000 == 0 {
                     eprintln!("Processed {} comparisons", i);
@@ -121,16 +137,13 @@ pub fn multisearch(
             }
         })
         .flatten()
-        .try_for_each_with(send, |s, m| s.send(m));
+        // .try_for_each_with(send, |s, m| s.send(m));
+        .try_for_each_with(qmanager_shared.clone(), |manager, result| {
+            manager.lock().unwrap().send(result)
+        })?;
 
     // do some cleanup and error handling -
-    if let Err(e) = send {
-        eprintln!("Unable to send internal data: {:?}", e);
-    }
-
-    if let Err(e) = thrd.join() {
-        eprintln!("Unable to join internal thread: {:?}", e);
-    }
+    manager_shared.lock().unwrap().perform_cleanup();
 
     // done!
     let i: usize = processed_cmp.fetch_max(0, atomic::Ordering::SeqCst);

--- a/src/multisearch.rs
+++ b/src/multisearch.rs
@@ -70,7 +70,6 @@ pub fn multisearch(
     against
         .par_iter()
         .filter_map(|against| {
-            // let manager_clone = manager_shared.clone();
             let mut results = vec![];
             // search for matches & save containment.
             for query in queries.iter() {
@@ -137,8 +136,7 @@ pub fn multisearch(
             }
         })
         .flatten()
-        // .try_for_each_with(send, |s, m| s.send(m));
-        .try_for_each_with(qmanager_shared.clone(), |manager, result| {
+        .try_for_each_with(manager_shared.clone(), |manager, result| {
             manager.lock().unwrap().send(result)
         })?;
 

--- a/src/multisearch.rs
+++ b/src/multisearch.rs
@@ -79,6 +79,7 @@ pub fn multisearch(
                     .interrupted
                     .load(Ordering::SeqCst)
                 {
+                    println!("Ctrl-C received, signaling shutdown...");
                     return None; // Early exit if interrupted
                 }
                 let i = processed_cmp.fetch_add(1, atomic::Ordering::SeqCst);

--- a/src/pairwise.rs
+++ b/src/pairwise.rs
@@ -100,20 +100,24 @@ pub fn pairwise(
                     average_containment_ani = Some((qani + mani) / 2.);
                     max_containment_ani = Some(f64::max(qani, mani));
                 }
-                manager_clone.lock().unwrap().send(MultiSearchResult {
-                    query_name: query.name.clone(),
-                    query_md5: query.md5sum.clone(),
-                    match_name: against.name.clone(),
-                    match_md5: against.md5sum.clone(),
-                    containment: containment_q1_in_q2,
-                    max_containment,
-                    jaccard,
-                    intersect_hashes: overlap,
-                    query_containment_ani,
-                    match_containment_ani,
-                    average_containment_ani,
-                    max_containment_ani,
-                })
+                manager_clone
+                    .lock()
+                    .unwrap()
+                    .send(MultiSearchResult {
+                        query_name: query.name.clone(),
+                        query_md5: query.md5sum.clone(),
+                        match_name: against.name.clone(),
+                        match_md5: against.md5sum.clone(),
+                        containment: containment_q1_in_q2,
+                        max_containment,
+                        jaccard,
+                        intersect_hashes: overlap,
+                        query_containment_ani,
+                        match_containment_ani,
+                        average_containment_ani,
+                        max_containment_ani,
+                    })
+                    .unwrap()
             }
 
             let i = processed_cmp.fetch_add(1, atomic::Ordering::SeqCst);
@@ -134,20 +138,24 @@ pub fn pairwise(
                 max_containment_ani = Some(1.0);
             }
 
-            manager_clone.lock().unwrap().send(MultiSearchResult {
-                query_name: query.name.clone(),
-                query_md5: query.md5sum.clone(),
-                match_name: query.name.clone(),
-                match_md5: query.md5sum.clone(),
-                containment: 1.0,
-                max_containment: 1.0,
-                jaccard: 1.0,
-                intersect_hashes: query.minhash.size() as f64,
-                query_containment_ani,
-                match_containment_ani,
-                average_containment_ani,
-                max_containment_ani,
-            })
+            manager_clone
+                .lock()
+                .unwrap()
+                .send(MultiSearchResult {
+                    query_name: query.name.clone(),
+                    query_md5: query.md5sum.clone(),
+                    match_name: query.name.clone(),
+                    match_md5: query.md5sum.clone(),
+                    containment: 1.0,
+                    max_containment: 1.0,
+                    jaccard: 1.0,
+                    intersect_hashes: query.minhash.size() as f64,
+                    query_containment_ani,
+                    match_containment_ani,
+                    average_containment_ani,
+                    max_containment_ani,
+                })
+                .unwrap()
         }
     });
 

--- a/src/pairwise.rs
+++ b/src/pairwise.rs
@@ -3,9 +3,11 @@ use anyhow::Result;
 use rayon::prelude::*;
 use std::sync::atomic;
 use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use crate::utils::{
-    csvwriter_thread, load_collection, load_sketches, MultiSearchResult, ReportType,
+    csvwriter_thread, load_collection, load_sketches, MultiSearchResult, ReportType, ThreadManager,
 };
 use sourmash::ani_utils::ani_from_containment;
 use sourmash::selection::Selection;
@@ -47,6 +49,12 @@ pub fn pairwise(
     // // & spawn a thread that is dedicated to printing to a buffered output
     let thrd = csvwriter_thread(recv, output);
 
+    // set up manager to allow for ctrl-c handling
+    let manager = ThreadManager::new(send, thrd);
+
+    // Wrap ThreadManager in Arc<Mutex> for safe sharing across threads
+    let manager_shared = Arc::new(Mutex::new(manager));
+
     //
     // Main loop: iterate (in parallel) over all signature,
     // Results written to the writer thread above.
@@ -55,8 +63,18 @@ pub fn pairwise(
     let ksize = selection.ksize().unwrap() as f64;
 
     sketches.par_iter().enumerate().for_each(|(idx, query)| {
+        // Clone the Arc to get a new reference for this thread
+        let manager_clone = manager_shared.clone();
         let mut has_written_comparison = false;
         for against in sketches.iter().skip(idx + 1) {
+            if manager_shared
+                .lock()
+                .unwrap()
+                .interrupted
+                .load(atomic::Ordering::SeqCst)
+            {
+                return; // Early return to stop processing further
+            }
             let overlap = query.minhash.count_common(&against.minhash, false).unwrap() as f64;
             let query1_size = query.minhash.size() as f64;
             let query2_size = against.minhash.size() as f64;
@@ -82,7 +100,7 @@ pub fn pairwise(
                     average_containment_ani = Some((qani + mani) / 2.);
                     max_containment_ani = Some(f64::max(qani, mani));
                 }
-                send.send(MultiSearchResult {
+                manager_clone.lock().unwrap().send(MultiSearchResult {
                     query_name: query.name.clone(),
                     query_md5: query.md5sum.clone(),
                     match_name: against.name.clone(),
@@ -96,7 +114,6 @@ pub fn pairwise(
                     average_containment_ani,
                     max_containment_ani,
                 })
-                .unwrap();
             }
 
             let i = processed_cmp.fetch_add(1, atomic::Ordering::SeqCst);
@@ -117,7 +134,7 @@ pub fn pairwise(
                 max_containment_ani = Some(1.0);
             }
 
-            send.send(MultiSearchResult {
+            manager_clone.lock().unwrap().send(MultiSearchResult {
                 query_name: query.name.clone(),
                 query_md5: query.md5sum.clone(),
                 match_name: query.name.clone(),
@@ -131,16 +148,11 @@ pub fn pairwise(
                 average_containment_ani,
                 max_containment_ani,
             })
-            .unwrap();
         }
     });
 
     // do some cleanup and error handling -
-    drop(send); // close the channel
-
-    if let Err(e) = thrd.join() {
-        eprintln!("Unable to join internal thread: {:?}", e);
-    }
+    manager_shared.lock().unwrap().perform_cleanup();
 
     // done!
     let i: usize = processed_cmp.load(atomic::Ordering::SeqCst);

--- a/src/pairwise.rs
+++ b/src/pairwise.rs
@@ -73,6 +73,7 @@ pub fn pairwise(
                 .interrupted
                 .load(atomic::Ordering::SeqCst)
             {
+                println!("Ctrl-C received, signaling shutdown...");
                 return; // Early return to stop processing further
             }
             let overlap = query.minhash.count_common(&against.minhash, false).unwrap() as f64;

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from .sourmash_tst_utils import TempDirectory, RunnerContext
@@ -6,3 +7,7 @@ from .sourmash_tst_utils import TempDirectory, RunnerContext
 def runtmp():
     with TempDirectory() as location:
         yield RunnerContext(location)
+
+# Set environment variable PYTEST_RUNNING
+def pytest_configure(config):
+    os.environ["PYTEST_RUNNING"] = "1"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,7 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::panic;
 use std::sync::atomic;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
-use std::sync::mpsc::SyncSender;
+use std::sync::mpsc::{SendError, SyncSender};
 use std::sync::Arc;
 
 use sourmash::collection::Collection;
@@ -54,12 +54,11 @@ impl<T: Serialize + Send + 'static> ThreadManager<T> {
         }
     }
 
-    pub fn send(&self, result: T) {
+    pub fn send(&self, result: T) -> Result<(), SendError<T>> {
         if let Some(ref sender) = self.sender {
-            sender.send(result).expect("Failed to send data");
+            sender.send(result)
         } else {
-            // Handle the case where sender is None. This could be a no-op or log an error.
-            eprintln!("Attempted to send data, but sender is closed.");
+            Err(SendError(result)) // send custom error instead?
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,7 +40,7 @@ impl<T: Send + 'static> ThreadManager<T> {
         if std::env::var("PYTEST_RUNNING").is_err() {
             // Only register the Ctrl-C handler if not running with pytest
             ctrlc::set_handler(move || {
-                eprintln!("Ctrl-C received, signaling shutdown...");
+                println!("Ctrl-C received, signaling shutdown...");
                 interrupted_clone.store(true, atomic::Ordering::SeqCst);
                 // Any additional shutdown logic can go here
             })
@@ -73,8 +73,6 @@ impl<T: Send + 'static> ThreadManager<T> {
                 Err(e) => eprintln!("Error joining CSV writer thread: {:?}", e),
             }
         }
-
-        println!("Cleanup complete.");
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -65,12 +65,11 @@ impl<T: Send + 'static> ThreadManager<T> {
     pub fn perform_cleanup(&mut self) {
         if let Some(sender) = self.sender.take() {
             drop(sender); // Close the channel
-            eprintln!("Channel closed.");
         }
 
         if let Some(thread) = self.writer_thread.take() {
             match thread.join() {
-                Ok(_) => println!("CSV writer thread successfully joined."),
+                Ok(_) => {}
                 Err(e) => eprintln!("Error joining CSV writer thread: {:?}", e),
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -912,30 +912,6 @@ pub struct MultiSearchResult {
     pub max_containment_ani: Option<f64>,
 }
 
-// define trait that can work on all SearchResult structs
-// really only using this to generalize ThreadManager
-// to do: make these more useful/descriptive?
-pub trait SearchResultTrait {
-    fn describe(&self) -> String;
-}
-
-impl SearchResultTrait for SearchResult {
-    fn describe(&self) -> String {
-        format!("Query: {}, Match: {}", self.query_name, self.match_name)
-    }
-}
-
-impl SearchResultTrait for BranchwaterGatherResult {
-    fn describe(&self) -> String {
-        format!("Query: {}, Match: {}", self.query_name, self.match_name)
-    }
-}
-impl SearchResultTrait for MultiSearchResult {
-    fn describe(&self) -> String {
-        format!("Query: {}, Match: {}", self.query_name, self.match_name)
-    }
-}
-
 pub fn open_stdout_or_file(output: Option<String>) -> Result<Box<dyn Write + Send>> {
     // if output is a file, use open_output_file
     match output {


### PR DESCRIPTION
addresses https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/40

This PR introduces a `ThreadManager` struct that contains a syncsender, a writer thread, and an atomic bool, `interrupted`, which is set to `true` if `Ctrl-C` is detected. 

```
pub struct ThreadManager<T: Send + 'static> {
    pub sender: Option<SyncSender<T>>,
    pub writer_thread: Option<std::thread::JoinHandle<Result<()>>>,
    pub interrupted: Arc<AtomicBool>,
}
```

`ThreadManager` has three functions:
- `new` for building a new instance and setting up `Ctrl-C` handling
- `send` for sending data to the writer thread
- `perform_cleanup`, to close the threads. This standardizes cleanup across interruption and successful completion.

In each main function, we instantiate a `ThreadManager` and wrap in in `Arc<Mutex>` for safe sharing across threads. Then, while iterating through e.g. queries or against signatures, we check the status of the `interrupted` bool each iteration. If `interrupted` is ever true, we return, foregoing the remaining iterations. 

Sometimes the return is faster than others -- it really depends on how long each iteration takes (aka how often we are checking for interruption).

This PR adds this `ctrl-c` capture to:
- `pairwise`
- `manysearch`
- `manysketch`
- `multisearch`
- rocksdb `fastmultigather`
- rocksdb `manysearch`

I want to punt the remaining commands to an issue for future work, since they require some refactoring (`fastgather`/`fastmultigather`/`cluster` do not use `send`/`recv`) or it wouldn't even really be useful (`index`, `check`) since we only provide a super lightweight wrapper around core functionality.

Notes/Questions:
- Pytest has its own Ctrl-C handler and we can't have two. So we only set up the Ctrl-C handling if we are _not_ running with pytest.
- How do I properly test this, other than just running?
- I have no idea if there are better ways to do this, but it seems logical to me and seems to work :) 

**In progress: benchmark to ensure this doesn't inflate runtimes.**

## benchmark summary

## 12k ICTV viral genomes, scaled=200

79.8m comparisons

| command | version | time |
| -------- | -------- | -------- |
| pairwise |  PR  | 17s     |
| pairwise | v0.9.1    | 20s     | 
| multisearch | PR  | 32s |
| multisearch | v0.9.1    | ?|
| manysketch | PR | 4 s |
| manysketch | v0.9.1 | ? |
| manysearch | PR | ? |
| manysearch | v0.9.1 | ? |
| rocksdb manysearch | PR | ? |
| rocksdb manysearch | v0.9.1 | ? |
| rocksdb fastmultigather | PR | ? |
| rocksdb fastmultigather | v0.9.1 | ? |