### PR TITLE
MRG: index should error out if no sigs to index

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -20,6 +20,13 @@ pub fn index<P: AsRef<Path>>(
         allow_failed_sigpaths,
     )?;
 
+    if collection.len() == 0 {
+        bail!(
+            "No sketches matching parameters, check input: '{}'",
+            &siglist
+        )
+    }
+
     RevIndex::create(
         output.as_ref(),
         collection.select(selection)?.try_into()?,

--- a/src/python/tests/test_index.py
+++ b/src/python/tests/test_index.py
@@ -161,8 +161,28 @@ def test_index_empty_siglist(runtmp, capfd):
     assert "Error: Signatures failed to load. Exiting." in captured.err
 
 
-def test_index_nomatch_sig_in_siglist(runtmp, capfd):
+def test_index_nomatch(runtmp, capfd):
     # test index with a siglist file that has (only) a non-matching ksize sig
+    siglist = runtmp.output('against.txt')
+    db = runtmp.output('db.rdb')
+
+    sig1 = get_test_data('1.fa.k21.sig.gz')
+    make_file_list(siglist, [sig1])
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'index', siglist,
+                        '-o', db)
+
+    captured = capfd.readouterr()
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
+    print(captured.out)
+    print(captured.err)
+    assert not os.path.exists(db)
+
+
+def test_index_nomatch_sig_in_siglist(runtmp, capfd):
+    # test index with a siglist file that has both matching and non-matching sigs
     siglist = runtmp.output('against.txt')
     db = runtmp.output('db.rdb')
 
@@ -174,10 +194,11 @@ def test_index_nomatch_sig_in_siglist(runtmp, capfd):
                         '-o', db)
 
     captured = capfd.readouterr()
-    assert os.path.exists(db) # currently empty file
     print(runtmp.last_result.out)
     print(runtmp.last_result.err)
+    print(captured.out)
     print(captured.err)
+    assert os.path.exists(db)
 
 
 def test_index_zipfile(runtmp, capfd):


### PR DESCRIPTION
`index` has been failing silently if there are no signatures to index by producing a rocksdb database that is just empty of sigs. It's been quite frustrating with issues arising from protein databases with pre-0.9.0 (aka incorrect) manifests :).

This PR changes `index` to Error out if there are no sigs to index.


I thought this had been handled as per https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/207, but regardless, it is fixed here.