### PR TITLE
MRG: fail-exit when 0 signatures are loaded from a collection

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -20,13 +20,6 @@ pub fn index<P: AsRef<Path>>(
         allow_failed_sigpaths,
     )?;
 
-    if collection.len() == 0 {
-        bail!(
-            "No sketches matching parameters, check input: '{}'",
-            &siglist
-        )
-    }
-
     RevIndex::create(
         output.as_ref(),
         collection.select(selection)?.try_into()?,

--- a/src/python/tests/test_multigather.py
+++ b/src/python/tests/test_multigather.py
@@ -543,7 +543,8 @@ def test_empty_against(runtmp, capfd):
     against_list = runtmp.output('against.txt')
     make_file_list(against_list, [])
 
-    runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
                         '-s', '100000')
 
     captured = capfd.readouterr()

--- a/src/python/tests/test_multisearch.py
+++ b/src/python/tests/test_multisearch.py
@@ -421,7 +421,7 @@ def test_bad_against(runtmp, capfd):
 
 
 def test_empty_query(runtmp, capfd):
-    # test with an empty query list - fail gracefully
+    # test with an empty query list - fail with error
     query_list = runtmp.output('query.txt')
     against_list = runtmp.output('against.txt')
 
@@ -434,7 +434,8 @@ def test_empty_query(runtmp, capfd):
 
     output = runtmp.output('out.csv')
 
-    runtmp.sourmash('scripts', 'multisearch', query_list, against_list,
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'multisearch', query_list, against_list,
                         '-o', output)
 
     print(runtmp.last_result.err)

--- a/src/python/tests/test_search.py
+++ b/src/python/tests/test_search.py
@@ -422,7 +422,8 @@ def test_nomatch_against(runtmp, capfd):
 
     output = runtmp.output('out.csv')
 
-    runtmp.sourmash('scripts', 'manysearch', query_list, against_list,
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'manysearch', query_list, against_list,
                         '-o', output)
 
     captured = capfd.readouterr()
@@ -470,7 +471,8 @@ def test_empty_query(runtmp, indexed, capfd):
 
     output = runtmp.output('out.csv')
 
-    runtmp.sourmash('scripts', 'manysearch', query_list, against_list,
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'manysearch', query_list, against_list,
                         '-o', output)
 
     print(runtmp.last_result.err)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -788,8 +788,7 @@ pub fn report_on_collection_loading(
 
     // Validate sketches
     if collection.is_empty() {
-        eprintln!("No {} signatures loaded, exiting.", report_type);
-        return Ok(());
+        bail!("No {} signatures loaded, exiting.", report_type);
     }
     eprintln!("Loaded {} {} signature(s)", collection.len(), report_type);
     Ok(())


### PR DESCRIPTION
Error out when 0 signatures are loaded from a collection. 

Since we currently only load a single collection as our query or database, 0 sigs in either means that no useful results would be obtained.

- Fixes #207 