### PR TITLE
MRG: fix manysketch naming bug

### DIFF
--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -226,7 +226,6 @@ pub fn manysketch(
                                     sig.set_name(name);
                                     // sourmash sets filename to last filename if merging fastas
                                     sig.set_filename(last_filename.as_str());
-                                    set_name = true;
                                 };
                                 if moltype == "protein" {
                                     sig.add_protein(&record.seq())
@@ -237,6 +236,9 @@ pub fn manysketch(
                                     // if not force, panics with 'N' in dna sequence
                                 }
                             });
+                            if !set_name {
+                                set_name = true;
+                            }
                         }
                         Err(err) => eprintln!("Error while processing record: {:?}", err),
                     }

--- a/src/python/tests/test_sketch.py
+++ b/src/python/tests/test_sketch.py
@@ -89,6 +89,12 @@ def test_manysketch_mult_k(runtmp):
 
     assert len(sigs) == 6
 
+    names = [sig.name for sig in sigs]
+    print(names)
+    assert names.count('short') == 2
+    assert names.count('short2') == 2
+    assert names.count('short3') == 2
+
 
 def test_manysketch_mult_k_2(runtmp):
     fa_csv = runtmp.output('db-fa.txt')
@@ -114,6 +120,12 @@ def test_manysketch_mult_k_2(runtmp):
     print(sigs)
 
     assert len(sigs) == 6
+
+    names = [sig.name for sig in sigs]
+    print(names)
+    assert names.count('short') == 2
+    assert names.count('short2') == 2
+    assert names.count('short3') == 2
 
 
 def test_manysketch_mult_moltype(runtmp):
@@ -148,10 +160,12 @@ def test_manysketch_mult_moltype(runtmp):
                 assert sig.minhash.scaled == 1
                 assert sig.md5sum() == "1474578c5c46dd09da4c2df29cf86621"
             else:
+                assert sig.name == 'short'
                 assert sig.minhash.ksize == 10
                 assert sig.minhash.scaled == 1
                 assert sig.md5sum() == "eb4467d11e0ecd2dbde4193bfc255310"
         else:
+            assert sig.name in ['short', 'short2', 'short3']
             assert sig.minhash.ksize == 21
             assert sig.minhash.scaled == 1
             assert sig.minhash.is_dna


### PR DESCRIPTION
- fixes #282

This bug caused sketch names to be set only for the first sketch for a given file, and _not_ set for any additional sketches. This means, if we were sketching at `k=21,k=31,k=51`, only the `k=21` sketches would have the name properly set.

