### PR TITLE
MRG: bump version to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "sourmash_plugin_branchwater"
-version = "0.9.3-dev"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash_plugin_branchwater"
-version = "0.9.3-dev"
+version = "0.9.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What's Changed
* MRG: bump version to v0.9.3-dev by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/278
* MRG: fix manysketch naming bug by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/284
* MRG: fail-exit when 0 signatures are loaded from a collection by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/282


**Full Changelog**: https://github.com/sourmash-bio/sourmash_plugin_branchwater/compare/v0.9.2...v0.9.3