### PR TITLE
MRG: write full gather result from `fastgather` and non-rocksdb `fastmultigather`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,7 @@ dependencies = [
  "serde_json",
  "simple-error",
  "sourmash",
+ "streaming-stats",
  "tempfile",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,9 +482,9 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -627,9 +627,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "histogram"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b634390eb8a63662e127836d4e2f26d7ae930600d4e05ee0fd85a009eeb1175"
+checksum = "f4d3bddd75a32b17e75762f128ffc7a33158b933b6eb27424da9be4a58f30eb9"
 dependencies = [
  "thiserror",
 ]
@@ -1677,8 +1677,7 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 [[package]]
 name = "sourmash"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084cf7e17f32408757d20fea1b6c09ed3dafdac4b894302e29906b51e0eac739"
+source = "git+https://github.com/sourmash-bio/sourmash?branch=latest#c205057deb67cc8730a72ce2d58f442a6e70edfd"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,9 +627,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "histogram"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d3bddd75a32b17e75762f128ffc7a33158b933b6eb27424da9be4a58f30eb9"
+checksum = "4b634390eb8a63662e127836d4e2f26d7ae930600d4e05ee0fd85a009eeb1175"
 dependencies = [
  "thiserror",
 ]
@@ -1677,7 +1677,8 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 [[package]]
 name = "sourmash"
 version = "0.13.1"
-source = "git+https://github.com/sourmash-bio/sourmash?branch=latest#c205057deb67cc8730a72ce2d58f442a6e70edfd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084cf7e17f32408757d20fea1b6c09ed3dafdac4b894302e29906b51e0eac739"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ csv = "1.3.0"
 camino = "1.1.6"
 glob = "0.3.1"
 rustworkx-core = "0.14.2"
+streaming-stats = "0.2.3"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -18,7 +18,6 @@ pub fn fastgather(
     gather_output: Option<String>,
     prefetch_output: Option<String>,
     allow_failed_sigpaths: bool,
-    make_full_result: bool,
 ) -> Result<()> {
     let query_collection = load_collection(
         &query_filepath,
@@ -100,7 +99,6 @@ pub fn fastgather(
         matchlist,
         threshold_hashes,
         gather_output,
-        make_full_result,
     )
     .ok();
     Ok(())

--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -18,6 +18,7 @@ pub fn fastgather(
     gather_output: Option<String>,
     prefetch_output: Option<String>,
     allow_failed_sigpaths: bool,
+    make_full_result: bool,
 ) -> Result<()> {
     let query_collection = load_collection(
         &query_filepath,
@@ -93,6 +94,13 @@ pub fn fastgather(
     }
 
     // run the gather!
-    consume_query_by_gather(query_sig, matchlist, threshold_hashes, gather_output).ok();
+    consume_query_by_gather(
+        query_sig,
+        matchlist,
+        threshold_hashes,
+        gather_output,
+        make_full_result,
+    )
+    .ok();
     Ok(())
 }

--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -96,6 +96,7 @@ pub fn fastgather(
     // run the gather!
     consume_query_by_gather(
         query_sig,
+        scaled as u64,
         matchlist,
         threshold_hashes,
         gather_output,

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -81,6 +81,7 @@ pub fn fastmultigather(
                                         name: against.name.clone(),
                                         md5sum: against.md5sum.clone(),
                                         minhash: against.minhash.clone(),
+                                        location: against.location.clone(),
                                         overlap,
                                     };
                                     mm = Some(result);

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -99,6 +99,7 @@ pub fn fastmultigather(
                         // Now, do the gather!
                         consume_query_by_gather(
                             query_sig.clone(),
+                            scaled as u64,
                             matchlist,
                             threshold_hashes,
                             Some(gather_output),

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -23,6 +23,7 @@ pub fn fastmultigather(
     scaled: usize,
     selection: &Selection,
     allow_failed_sigpaths: bool,
+    make_full_result: bool,
 ) -> Result<()> {
     // load query collection
     let query_collection = load_collection(
@@ -101,6 +102,7 @@ pub fn fastmultigather(
                             matchlist,
                             threshold_hashes,
                             Some(gather_output),
+                            make_full_result,
                         )
                         .ok();
                     } else {

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -23,7 +23,6 @@ pub fn fastmultigather(
     scaled: usize,
     selection: &Selection,
     allow_failed_sigpaths: bool,
-    make_full_result: bool,
 ) -> Result<()> {
     // load query collection
     let query_collection = load_collection(
@@ -104,7 +103,6 @@ pub fn fastmultigather(
                             matchlist,
                             threshold_hashes,
                             Some(gather_output),
-                            make_full_result,
                         )
                         .ok();
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,6 @@ fn do_fastgather(
     ksize: u8,
     scaled: usize,
     moltype: String,
-    make_full_result: bool,
     output_path_prefetch: Option<String>,
     output_path_gather: Option<String>,
 ) -> anyhow::Result<u8> {
@@ -95,7 +94,6 @@ fn do_fastgather(
         output_path_prefetch,
         output_path_gather,
         allow_failed_sigpaths,
-        make_full_result,
     ) {
         Ok(_) => Ok(0),
         Err(e) => {
@@ -113,7 +111,6 @@ fn do_fastmultigather(
     ksize: u8,
     scaled: usize,
     moltype: String,
-    make_full_result: bool,
     output_path: Option<String>,
 ) -> anyhow::Result<u8> {
     let againstfile_path: camino::Utf8PathBuf = siglist_path.clone().into();
@@ -137,7 +134,7 @@ fn do_fastmultigather(
             }
         }
     } else {
-        if let Some(_) = output_path {
+        if output_path.is_some() {
             bail!("output path specified, but not running fastmultigather against a rocksdb. See issue #239");
         }
         match fastmultigather::fastmultigather(
@@ -147,7 +144,6 @@ fn do_fastmultigather(
             scaled,
             &selection,
             allow_failed_sigpaths,
-            make_full_result,
         ) {
             Ok(_) => Ok(0),
             Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ fn do_fastgather(
     ksize: u8,
     scaled: usize,
     moltype: String,
+    make_full_result: bool,
     output_path_prefetch: Option<String>,
     output_path_gather: Option<String>,
 ) -> anyhow::Result<u8> {
@@ -94,6 +95,7 @@ fn do_fastgather(
         output_path_prefetch,
         output_path_gather,
         allow_failed_sigpaths,
+        make_full_result,
     ) {
         Ok(_) => Ok(0),
         Err(e) => {
@@ -111,6 +113,7 @@ fn do_fastmultigather(
     ksize: u8,
     scaled: usize,
     moltype: String,
+    make_full_result: bool,
     output_path: Option<String>,
 ) -> anyhow::Result<u8> {
     let againstfile_path: camino::Utf8PathBuf = siglist_path.clone().into();
@@ -141,6 +144,7 @@ fn do_fastmultigather(
             scaled,
             &selection,
             allow_failed_sigpaths,
+            make_full_result,
         ) {
             Ok(_) => Ok(0),
             Err(e) => {

--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -101,7 +101,6 @@ class Branchwater_Fastgather(CommandLinePlugin):
                        help='scaled factor at which to do comparisons (default: 1000)')
         p.add_argument('-m', '--moltype', default='DNA', choices = ["DNA", "protein", "dayhoff", "hp"],
                        help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
-        p.add_argument('--full-results', action='store_true', default=False, help = 'produce full gather results')
         p.add_argument('-c', '--cores', default=0, type=int,
                 help='number of cores to use (default is all available)')
 
@@ -122,7 +121,6 @@ class Branchwater_Fastgather(CommandLinePlugin):
                                                            args.ksize,
                                                            args.scaled,
                                                            args.moltype,
-                                                           args.full_results,
                                                            args.output_gather,
                                                            args.output_prefetch)
         if status == 0:
@@ -149,7 +147,6 @@ class Branchwater_Fastmultigather(CommandLinePlugin):
                        help='scaled factor at which to do comparisons (default: 1000)')
         p.add_argument('-m', '--moltype', default='DNA', choices = ["DNA", "protein", "dayhoff", "hp"],
                        help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
-        p.add_argument('--full-results', action='store_true', default=False, help = 'produce full gather results')
         p.add_argument('-c', '--cores', default=0, type=int,
                 help='number of cores to use (default is all available)')
         p.add_argument('-o', '--output', help='CSV output file for matches')
@@ -170,7 +167,6 @@ class Branchwater_Fastmultigather(CommandLinePlugin):
                                                                 args.ksize,
                                                                 args.scaled,
                                                                 args.moltype,
-                                                                args.full_results,
                                                                 args.output)
         if status == 0:
             notify(f"...fastmultigather is done!")

--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -101,6 +101,7 @@ class Branchwater_Fastgather(CommandLinePlugin):
                        help='scaled factor at which to do comparisons (default: 1000)')
         p.add_argument('-m', '--moltype', default='DNA', choices = ["DNA", "protein", "dayhoff", "hp"],
                        help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
+        p.add_argument('--full-results', action='store_true', default=False, help = 'produce full gather results')
         p.add_argument('-c', '--cores', default=0, type=int,
                 help='number of cores to use (default is all available)')
 
@@ -121,6 +122,7 @@ class Branchwater_Fastgather(CommandLinePlugin):
                                                            args.ksize,
                                                            args.scaled,
                                                            args.moltype,
+                                                           args.full_results,
                                                            args.output_gather,
                                                            args.output_prefetch)
         if status == 0:
@@ -147,6 +149,7 @@ class Branchwater_Fastmultigather(CommandLinePlugin):
                        help='scaled factor at which to do comparisons (default: 1000)')
         p.add_argument('-m', '--moltype', default='DNA', choices = ["DNA", "protein", "dayhoff", "hp"],
                        help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
+        p.add_argument('--full-results', action='store_true', default=False, help = 'produce full gather results')
         p.add_argument('-c', '--cores', default=0, type=int,
                 help='number of cores to use (default is all available)')
         p.add_argument('-o', '--output', help='CSV output file for matches')
@@ -167,6 +170,7 @@ class Branchwater_Fastmultigather(CommandLinePlugin):
                                                                 args.ksize,
                                                                 args.scaled,
                                                                 args.moltype,
+                                                                args.full_results,
                                                                 args.output)
         if status == 0:
             notify(f"...fastmultigather is done!")

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -781,25 +781,67 @@ def test_fullres_vs_sourmash_gather(runtmp):
     fmg_intersect_bp = set(gather_df['intersect_bp'])
     g_intersect_bp = set(sourmash_gather_df['intersect_bp'])
     assert fmg_intersect_bp == g_intersect_bp == set([4400000, 4100000, 2200000])
+
+    fmg_f_orig_query =  set([round(x,4) for x in gather_df['f_orig_query']])
+    g_f_orig_query =  set([round(x,4) for x in sourmash_gather_df['f_orig_query']])
+    assert fmg_f_orig_query == g_f_orig_query == set([0.0098, 0.0105, 0.0052])
+
     fmg_f_unique_to_query =  set([round(x,3) for x in gather_df['f_unique_to_query']]) # rounding to 4 --> slightly different!
     g_f_unique_to_query =  set([round(x,3) for x in sourmash_gather_df['f_unique_to_query']])
     assert fmg_f_unique_to_query == g_f_unique_to_query == set([0.004, 0.01, 0.005])
+
+    fmg_f_unique_weighted =  set([round(x,4) for x in gather_df['f_unique_weighted']])
+    g_f_unique_weighted =  set([round(x,4) for x in sourmash_gather_df['f_unique_weighted']])
+    assert fmg_f_unique_weighted== g_f_unique_weighted == set([0.0063, 0.002, 0.0062])
+
+    fmg_average_abund =  set([round(x,4) for x in gather_df['average_abund']])
+    g_average_abund =  set([round(x,4) for x in sourmash_gather_df['average_abund']])
+    assert fmg_average_abund== g_average_abund == set([8.2222, 10.3864, 21.0455])
+
+    fmg_median_abund =  set([round(x,4) for x in gather_df['median_abund']])
+    g_median_abund =  set([round(x,4) for x in sourmash_gather_df['median_abund']])
+    assert fmg_median_abund== g_median_abund == set([8.0, 10.5, 21.5])
+
+    fmg_std_abund =  set([round(x,4) for x in gather_df['std_abund']])
+    g_std_abund =  set([round(x,4) for x in sourmash_gather_df['std_abund']])
+    assert fmg_std_abund== g_std_abund == set([3.172, 5.6446, 6.9322])
+
+    # we can't get match filename in FMG yet.
+    # fmg_match_filename =  set(gather_df['match_filename'])
+    # assert fmg_match_filename == [] all are nans rn..{nan, nan, nan}
+    g_match_filename =  sourmash_gather_df['filename']
+    g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
+    assert all([x in g_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+
+    assert list(sourmash_gather_df['name']) == list(gather_df['match_name'])
+    assert list(sourmash_gather_df['md5']) == list(gather_df['match_md5'])
+
+    fmg_f_match_orig =  set([round(x,4) for x in gather_df['f_match_orig']])
+    g_f_match_orig =  set([round(x,4) for x in sourmash_gather_df['f_match_orig']])
+    assert fmg_f_match_orig == g_f_match_orig == set([1.0])
+
     fmg_f_match =  set([round(x,4) for x in gather_df['f_match']])
     g_f_match =  set([round(x,4) for x in sourmash_gather_df['f_match']])
     assert fmg_f_match == g_f_match == set([0.439, 1.0])
+
     fmg_unique_intersect_bp = set(gather_df['unique_intersect_bp'])
     g_unique_intersect_bp = set(sourmash_gather_df['unique_intersect_bp'])
     assert fmg_unique_intersect_bp == g_unique_intersect_bp == set([4400000, 1800000, 2200000])
-    fmg_remaining_bp = set(gather_df['remaining_bp'])
-    g_remaining_bp = set(sourmash_gather_df['remaining_bp'])
-    print(g_remaining_bp) #{4000000, 0, 1800000}
-    print(fmg_remaining_bp) # {415600000, 411600000, 413400000}
-    # assert fmg_remaining_bp == g_remaining_bp == set([73489]) # FIXME
+
     fmg_total_weighted_hashes= set(gather_df['total_weighted_hashes'])
     g_total_weighted_hashes = set(sourmash_gather_df['total_weighted_hashes'])
     assert fmg_total_weighted_hashes == g_total_weighted_hashes == set([73489])
 
+    fmg_gather_result_rank= set(gather_df['gather_result_rank'])
+    g_gather_result_rank = set(sourmash_gather_df['gather_result_rank'])
+    assert fmg_gather_result_rank == g_gather_result_rank == set([0,1,2])
 
+    # FIX remaining_bp
+    fmg_remaining_bp = set(gather_df['remaining_bp'])
+    g_remaining_bp = set(sourmash_gather_df['remaining_bp'])
+    print(g_remaining_bp) #{4000000, 0, 1800000}
+    print(fmg_remaining_bp) # {415600000, 411600000, 413400000}
+    # assert fmg_remaining_bp == g_remaining_bp == set([])
 
     # f_unique_to_query = set([round(x,4) for x in df['f_unique_to_query']])
     # assert f_unique_to_query == set([0.0053, 0.0105, 0.0044])

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -55,7 +55,7 @@ def test_simple(runtmp, zip_against):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
 
 
 @pytest.mark.parametrize('zip_against', [False, True])
@@ -85,7 +85,7 @@ def test_simple_with_prefetch(runtmp, zip_against):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
 
     df = pandas.read_csv(p_output)
     assert len(df) == 3
@@ -199,7 +199,7 @@ def test_sig_against(runtmp, capfd):
     df = pandas.read_csv(g_output)
     assert len(df) == 1
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
 
 
 def test_bad_against(runtmp, capfd):
@@ -399,7 +399,7 @@ def test_md5s(runtmp, zip_against):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
 
     md5s = list(df['match_md5'])
     print(md5s)
@@ -456,13 +456,14 @@ def test_csv_columns_vs_sourmash_prefetch(runtmp, zip_against):
 
     gather_df = pandas.read_csv(g_output)
     g_keys = set(gather_df.keys())
-    assert g_keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
-    g_keys.remove('rank')       # 'rank' is not in sourmash prefetch!
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(g_keys)
+    g_keys.remove('gather_result_rank')       # 'gather_result_rank' is not in sourmash prefetch!
 
     sourmash_prefetch_df = pandas.read_csv(sp_output)
     sp_keys = set(sourmash_prefetch_df.keys())
     print(g_keys - sp_keys)
-    assert not g_keys - sp_keys, g_keys - sp_keys
+    diff_keys = g_keys - sp_keys
+    assert diff_keys == set(['unique_intersect_bp', 'median_abund', 'f_match_orig', 'std_abund', 'average_abund', 'f_unique_to_query', 'remaining_bp', 'f_unique_weighted', 'sum_weighted_found', 'total_weighted_hashes', 'n_unique_weighted_found', 'f_orig_query', 'f_match'])
 
 
 @pytest.mark.parametrize('zip_against', [False, True])
@@ -571,7 +572,7 @@ def test_simple_protein(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 1
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
     print(df)
     assert df['match_md5'][0] == "16869d2c8a1d29d1c8e56f5c561e585e"
 
@@ -598,7 +599,7 @@ def test_simple_dayhoff(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 1
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
     print(df)
     assert df['match_md5'][0] == "fbca5e5211e4d58427997fd5c8343e9a"
 
@@ -625,7 +626,7 @@ def test_simple_hp(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 1
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
     print(df)
     assert df['match_md5'][0] == "ea2a1ad233c2908529d124a330bcb672"
 
@@ -685,7 +686,7 @@ def test_simple_with_manifest_loading(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}.issubset(keys)
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
 
 
 def test_simple_full_output(runtmp):
@@ -703,7 +704,7 @@ def test_simple_full_output(runtmp):
     p_output = runtmp.output('prefetch.csv')
 
     runtmp.sourmash('scripts', 'fastgather', query, against_list,
-                    '-o', g_output, '-s', '100000', '--full-results')
+                    '-o', g_output, '-s', '100000')
     assert os.path.exists(g_output)
 
     df = pandas.read_csv(g_output)
@@ -726,13 +727,12 @@ def test_simple_full_output(runtmp):
         for ss in sourmash.load_file_as_signatures(against_file, ksize=31):
             assert ss.md5sum() in md5s
 
-
     intersect_bp = set(df['intersect_bp'])
     assert intersect_bp == set([4400000, 4100000, 2200000])
     f_unique_to_query = set([round(x,4) for x in df['f_unique_to_query']])
-    assert f_unique_to_query == set([0.0053, 0.0105, 0.0044])
+    assert f_unique_to_query == set([0.0052, 0.0105, 0.0043])
     query_containment_ani = set([round(x,4) for x in df['query_containment_ani']])
-    assert query_containment_ani == set([0.8632, 0.8444, 0.8391])
+    assert query_containment_ani == set([0.8632, 0.8442, 0.8387])
     print(query_containment_ani)
     for index, row in df.iterrows():
         print(row.to_dict())
@@ -754,7 +754,7 @@ def test_fullres_vs_sourmash_gather(runtmp):
     g_output = runtmp.output('SRR606249.gather.csv')
     runtmp.sourmash('scripts', 'fastgather', query_list,
                     against_list, '-s', '100000', '-t', '0',
-                    '--full-results', '-o', g_output)
+                    '-o', g_output)
 
     print(runtmp.last_result.out)
     print(runtmp.last_result.err)
@@ -837,9 +837,9 @@ def test_fullres_vs_sourmash_gather(runtmp):
     #print("gather remaining bp: ", g_remaining_bp) #{4000000, 0, 1800000}
     # assert fg_remaining_bp == g_remaining_bp == set([])
     
-    fg_query_containment_ani = set([round(x,4) for x in gather_df['query_containment_ani']])
-    g_query_containment_ani = set([round(x,4) for x in sourmash_gather_df['query_containment_ani']])
-    assert fg_query_containment_ani == set([0.8632, 0.8444, 0.8391])
+    fg_query_containment_ani = set([round(x,3) for x in gather_df['query_containment_ani']])
+    g_query_containment_ani = set([round(x,3) for x in sourmash_gather_df['query_containment_ani']])
+    assert fg_query_containment_ani == set([0.863, 0.844, 0.839])
     # gather cANI are nans here -- perhaps b/c sketches too small?
     # assert fg_query_containment_ani == g_query_containment_ani == set([0.8632, 0.8444, 0.8391])
     print("fg qcANI: ", fg_query_containment_ani)

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -787,9 +787,17 @@ def test_fullres_vs_sourmash_gather(runtmp):
     fmg_f_match =  set([round(x,4) for x in gather_df['f_match']])
     g_f_match =  set([round(x,4) for x in sourmash_gather_df['f_match']])
     assert fmg_f_match == g_f_match == set([0.439, 1.0])
-    fmg_unique_intersect_bp = set(gather_df['unique_intersect_bp']) # FIXME
+    fmg_unique_intersect_bp = set(gather_df['unique_intersect_bp'])
     g_unique_intersect_bp = set(sourmash_gather_df['unique_intersect_bp'])
-    # assert fmg_unique_intersect_bp == g_intersect_bp == set([4400000, 1800000, 2200000])
+    assert fmg_unique_intersect_bp == g_unique_intersect_bp == set([4400000, 1800000, 2200000])
+    fmg_remaining_bp = set(gather_df['remaining_bp'])
+    g_remaining_bp = set(sourmash_gather_df['remaining_bp'])
+    print(g_remaining_bp) #{4000000, 0, 1800000}
+    print(fmg_remaining_bp) # {415600000, 411600000, 413400000}
+    # assert fmg_remaining_bp == g_remaining_bp == set([73489]) # FIXME
+    fmg_total_weighted_hashes= set(gather_df['total_weighted_hashes'])
+    g_total_weighted_hashes = set(sourmash_gather_df['total_weighted_hashes'])
+    assert fmg_total_weighted_hashes == g_total_weighted_hashes == set([73489])
 
 
 

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -810,12 +810,10 @@ def test_fullres_vs_sourmash_gather(runtmp):
     g_std_abund =  set([round(x,4) for x in sourmash_gather_df['std_abund']])
     assert fg_std_abund== g_std_abund == set([3.172, 5.6446, 6.9322])
 
-    # we can't get match filename in FG yet.
-    # fg_match_filename =  set(gather_df['match_filename'])
-    # assert fg_match_filename == [] all are nans rn..{nan, nan, nan}
-    g_match_filename =  sourmash_gather_df['filename']
     g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
-    assert all([x in g_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+    fg_match_filename_basename = [os.path.basename(filename) for filename in gather_df['match_filename']]
+    assert all([x in fg_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+    assert fg_match_filename_basename == g_match_filename_basename
 
     assert list(sourmash_gather_df['name']) == list(gather_df['match_name'])
     assert list(sourmash_gather_df['md5']) == list(gather_df['match_md5'])

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -739,7 +739,7 @@ def test_simple_full_output(runtmp):
 
 
 def test_fullres_vs_sourmash_gather(runtmp):
-    # the column names should be identical to sourmash gather cols
+    # fastgather results should match to sourmash gather results
     query = get_test_data('SRR606249.sig.gz')
 
     sig2 = get_test_data('2.fa.sig.gz')
@@ -775,44 +775,44 @@ def test_fullres_vs_sourmash_gather(runtmp):
     print('g_keys - sg_keys:', g_keys - sg_keys)
     assert not g_keys - sg_keys, g_keys - sg_keys
 
-    for index, row in sourmash_gather_df.iterrows():
+    for _idx, row in sourmash_gather_df.iterrows():
         print(row.to_dict())
 
-    fmg_intersect_bp = set(gather_df['intersect_bp'])
+    fg_intersect_bp = set(gather_df['intersect_bp'])
     g_intersect_bp = set(sourmash_gather_df['intersect_bp'])
-    assert fmg_intersect_bp == g_intersect_bp == set([4400000, 4100000, 2200000])
+    assert fg_intersect_bp == g_intersect_bp == set([4400000, 4100000, 2200000])
 
-    fmg_f_orig_query =  set([round(x,4) for x in gather_df['f_orig_query']])
+    fg_f_orig_query =  set([round(x,4) for x in gather_df['f_orig_query']])
     g_f_orig_query =  set([round(x,4) for x in sourmash_gather_df['f_orig_query']])
-    assert fmg_f_orig_query == g_f_orig_query == set([0.0098, 0.0105, 0.0052])
+    assert fg_f_orig_query == g_f_orig_query == set([0.0098, 0.0105, 0.0052])
 
-    fmg_f_match =  set([round(x,4) for x in gather_df['f_match']])
+    fg_f_match =  set([round(x,4) for x in gather_df['f_match']])
     g_f_match =  set([round(x,4) for x in sourmash_gather_df['f_match']])
-    assert fmg_f_match == g_f_match == set([0.439, 1.0])
+    assert fg_f_match == g_f_match == set([0.439, 1.0])
 
-    fmg_f_unique_to_query =  set([round(x,3) for x in gather_df['f_unique_to_query']]) # rounding to 4 --> slightly different!
+    fg_f_unique_to_query =  set([round(x,3) for x in gather_df['f_unique_to_query']]) # rounding to 4 --> slightly different!
     g_f_unique_to_query =  set([round(x,3) for x in sourmash_gather_df['f_unique_to_query']])
-    assert fmg_f_unique_to_query == g_f_unique_to_query == set([0.004, 0.01, 0.005])
+    assert fg_f_unique_to_query == g_f_unique_to_query == set([0.004, 0.01, 0.005])
 
-    fmg_f_unique_weighted =  set([round(x,4) for x in gather_df['f_unique_weighted']])
+    fg_f_unique_weighted =  set([round(x,4) for x in gather_df['f_unique_weighted']])
     g_f_unique_weighted =  set([round(x,4) for x in sourmash_gather_df['f_unique_weighted']])
-    assert fmg_f_unique_weighted== g_f_unique_weighted == set([0.0063, 0.002, 0.0062])
+    assert fg_f_unique_weighted== g_f_unique_weighted == set([0.0063, 0.002, 0.0062])
 
-    fmg_average_abund =  set([round(x,4) for x in gather_df['average_abund']])
+    fg_average_abund =  set([round(x,4) for x in gather_df['average_abund']])
     g_average_abund =  set([round(x,4) for x in sourmash_gather_df['average_abund']])
-    assert fmg_average_abund== g_average_abund == set([8.2222, 10.3864, 21.0455])
+    assert fg_average_abund== g_average_abund == set([8.2222, 10.3864, 21.0455])
 
-    fmg_median_abund =  set([round(x,4) for x in gather_df['median_abund']])
+    fg_median_abund =  set([round(x,4) for x in gather_df['median_abund']])
     g_median_abund =  set([round(x,4) for x in sourmash_gather_df['median_abund']])
-    assert fmg_median_abund== g_median_abund == set([8.0, 10.5, 21.5])
+    assert fg_median_abund== g_median_abund == set([8.0, 10.5, 21.5])
 
-    fmg_std_abund =  set([round(x,4) for x in gather_df['std_abund']])
+    fg_std_abund =  set([round(x,4) for x in gather_df['std_abund']])
     g_std_abund =  set([round(x,4) for x in sourmash_gather_df['std_abund']])
-    assert fmg_std_abund== g_std_abund == set([3.172, 5.6446, 6.9322])
+    assert fg_std_abund== g_std_abund == set([3.172, 5.6446, 6.9322])
 
-    # we can't get match filename in FMG yet.
-    # fmg_match_filename =  set(gather_df['match_filename'])
-    # assert fmg_match_filename == [] all are nans rn..{nan, nan, nan}
+    # we can't get match filename in FG yet.
+    # fg_match_filename =  set(gather_df['match_filename'])
+    # assert fg_match_filename == [] all are nans rn..{nan, nan, nan}
     g_match_filename =  sourmash_gather_df['filename']
     g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
     assert all([x in g_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
@@ -820,41 +820,41 @@ def test_fullres_vs_sourmash_gather(runtmp):
     assert list(sourmash_gather_df['name']) == list(gather_df['match_name'])
     assert list(sourmash_gather_df['md5']) == list(gather_df['match_md5'])
 
-    fmg_f_match_orig =  set([round(x,4) for x in gather_df['f_match_orig']])
+    fg_f_match_orig =  set([round(x,4) for x in gather_df['f_match_orig']])
     g_f_match_orig =  set([round(x,4) for x in sourmash_gather_df['f_match_orig']])
-    assert fmg_f_match_orig == g_f_match_orig == set([1.0])
+    assert fg_f_match_orig == g_f_match_orig == set([1.0])
 
-    fmg_unique_intersect_bp = set(gather_df['unique_intersect_bp'])
+    fg_unique_intersect_bp = set(gather_df['unique_intersect_bp'])
     g_unique_intersect_bp = set(sourmash_gather_df['unique_intersect_bp'])
-    assert fmg_unique_intersect_bp == g_unique_intersect_bp == set([4400000, 1800000, 2200000])
+    assert fg_unique_intersect_bp == g_unique_intersect_bp == set([4400000, 1800000, 2200000])
 
-    fmg_gather_result_rank= set(gather_df['gather_result_rank'])
+    fg_gather_result_rank= set(gather_df['gather_result_rank'])
     g_gather_result_rank = set(sourmash_gather_df['gather_result_rank'])
-    assert fmg_gather_result_rank == g_gather_result_rank == set([0,1,2])
+    assert fg_gather_result_rank == g_gather_result_rank == set([0,1,2])
     
-    fmg_remaining_bp = list(gather_df['remaining_bp'])
-    assert fmg_remaining_bp == [415600000, 413400000, 411600000]
+    fg_remaining_bp = list(gather_df['remaining_bp'])
+    assert fg_remaining_bp == [415600000, 413400000, 411600000]
     ### Gather remaining bp does not match, but I think this one is right?
     #g_remaining_bp = list(sourmash_gather_df['remaining_bp'])
     #print("gather remaining bp: ", g_remaining_bp) #{4000000, 0, 1800000}
-    # assert fmg_remaining_bp == g_remaining_bp == set([])
+    # assert fg_remaining_bp == g_remaining_bp == set([])
     
-    fmg_query_containment_ani = set([round(x,4) for x in gather_df['query_containment_ani']])
+    fg_query_containment_ani = set([round(x,4) for x in gather_df['query_containment_ani']])
     g_query_containment_ani = set([round(x,4) for x in sourmash_gather_df['query_containment_ani']])
-    assert fmg_query_containment_ani == set([0.8632, 0.8444, 0.8391])
-    # gather cANI are nans here -- perhaps b/c sketches too small
-    # assert fmg_query_containment_ani == g_query_containment_ani == set([0.8632, 0.8444, 0.8391])
-    print("fmg qcANI: ", fmg_query_containment_ani)
+    assert fg_query_containment_ani == set([0.8632, 0.8444, 0.8391])
+    # gather cANI are nans here -- perhaps b/c sketches too small?
+    # assert fg_query_containment_ani == g_query_containment_ani == set([0.8632, 0.8444, 0.8391])
+    print("fg qcANI: ", fg_query_containment_ani)
     print("g_qcANI: ", g_query_containment_ani)
 
-    fmg_n_unique_weighted_found= set(gather_df['n_unique_weighted_found'])
+    fg_n_unique_weighted_found= set(gather_df['n_unique_weighted_found'])
     g_n_unique_weighted_found = set(sourmash_gather_df['n_unique_weighted_found'])
-    assert fmg_n_unique_weighted_found == g_n_unique_weighted_found == set([457, 148, 463])
+    assert fg_n_unique_weighted_found == g_n_unique_weighted_found == set([457, 148, 463])
 
-    fmg_sum_weighted_found= set(gather_df['sum_weighted_found'])
+    fg_sum_weighted_found= set(gather_df['sum_weighted_found'])
     g_sum_weighted_found = set(sourmash_gather_df['sum_weighted_found'])
-    assert fmg_sum_weighted_found == g_sum_weighted_found == set([920, 457, 1068])
+    assert fg_sum_weighted_found == g_sum_weighted_found == set([920, 457, 1068])
     
-    fmg_total_weighted_hashes= set(gather_df['total_weighted_hashes'])
+    fg_total_weighted_hashes= set(gather_df['total_weighted_hashes'])
     g_total_weighted_hashes = set(sourmash_gather_df['total_weighted_hashes'])
-    assert fmg_total_weighted_hashes == g_total_weighted_hashes == set([73489])
+    assert fg_total_weighted_hashes == g_total_weighted_hashes == set([73489])

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -786,6 +786,10 @@ def test_fullres_vs_sourmash_gather(runtmp):
     g_f_orig_query =  set([round(x,4) for x in sourmash_gather_df['f_orig_query']])
     assert fmg_f_orig_query == g_f_orig_query == set([0.0098, 0.0105, 0.0052])
 
+    fmg_f_match =  set([round(x,4) for x in gather_df['f_match']])
+    g_f_match =  set([round(x,4) for x in sourmash_gather_df['f_match']])
+    assert fmg_f_match == g_f_match == set([0.439, 1.0])
+
     fmg_f_unique_to_query =  set([round(x,3) for x in gather_df['f_unique_to_query']]) # rounding to 4 --> slightly different!
     g_f_unique_to_query =  set([round(x,3) for x in sourmash_gather_df['f_unique_to_query']])
     assert fmg_f_unique_to_query == g_f_unique_to_query == set([0.004, 0.01, 0.005])
@@ -820,30 +824,37 @@ def test_fullres_vs_sourmash_gather(runtmp):
     g_f_match_orig =  set([round(x,4) for x in sourmash_gather_df['f_match_orig']])
     assert fmg_f_match_orig == g_f_match_orig == set([1.0])
 
-    fmg_f_match =  set([round(x,4) for x in gather_df['f_match']])
-    g_f_match =  set([round(x,4) for x in sourmash_gather_df['f_match']])
-    assert fmg_f_match == g_f_match == set([0.439, 1.0])
-
     fmg_unique_intersect_bp = set(gather_df['unique_intersect_bp'])
     g_unique_intersect_bp = set(sourmash_gather_df['unique_intersect_bp'])
     assert fmg_unique_intersect_bp == g_unique_intersect_bp == set([4400000, 1800000, 2200000])
 
-    fmg_total_weighted_hashes= set(gather_df['total_weighted_hashes'])
-    g_total_weighted_hashes = set(sourmash_gather_df['total_weighted_hashes'])
-    assert fmg_total_weighted_hashes == g_total_weighted_hashes == set([73489])
-
     fmg_gather_result_rank= set(gather_df['gather_result_rank'])
     g_gather_result_rank = set(sourmash_gather_df['gather_result_rank'])
     assert fmg_gather_result_rank == g_gather_result_rank == set([0,1,2])
-
-    # FIX remaining_bp
-    fmg_remaining_bp = set(gather_df['remaining_bp'])
-    g_remaining_bp = set(sourmash_gather_df['remaining_bp'])
-    print(g_remaining_bp) #{4000000, 0, 1800000}
-    print(fmg_remaining_bp) # {415600000, 411600000, 413400000}
+    
+    fmg_remaining_bp = list(gather_df['remaining_bp'])
+    assert fmg_remaining_bp == [415600000, 413400000, 411600000]
+    ### Gather remaining bp does not match, but I think this one is right?
+    #g_remaining_bp = list(sourmash_gather_df['remaining_bp'])
+    #print("gather remaining bp: ", g_remaining_bp) #{4000000, 0, 1800000}
     # assert fmg_remaining_bp == g_remaining_bp == set([])
+    
+    fmg_query_containment_ani = set([round(x,4) for x in gather_df['query_containment_ani']])
+    g_query_containment_ani = set([round(x,4) for x in sourmash_gather_df['query_containment_ani']])
+    assert fmg_query_containment_ani == set([0.8632, 0.8444, 0.8391])
+    # gather cANI are nans here -- perhaps b/c sketches too small
+    # assert fmg_query_containment_ani == g_query_containment_ani == set([0.8632, 0.8444, 0.8391])
+    print("fmg qcANI: ", fmg_query_containment_ani)
+    print("g_qcANI: ", g_query_containment_ani)
 
-    # f_unique_to_query = set([round(x,4) for x in df['f_unique_to_query']])
-    # assert f_unique_to_query == set([0.0053, 0.0105, 0.0044])
-    # query_containment_ani = set([round(x,4) for x in df['query_containment_ani']])
-    # assert query_containment_ani == set([0.8632, 0.8444, 0.8391])
+    fmg_n_unique_weighted_found= set(gather_df['n_unique_weighted_found'])
+    g_n_unique_weighted_found = set(sourmash_gather_df['n_unique_weighted_found'])
+    assert fmg_n_unique_weighted_found == g_n_unique_weighted_found == set([457, 148, 463])
+
+    fmg_sum_weighted_found= set(gather_df['sum_weighted_found'])
+    g_sum_weighted_found = set(sourmash_gather_df['sum_weighted_found'])
+    assert fmg_sum_weighted_found == g_sum_weighted_found == set([920, 457, 1068])
+    
+    fmg_total_weighted_hashes= set(gather_df['total_weighted_hashes'])
+    g_total_weighted_hashes = set(sourmash_gather_df['total_weighted_hashes'])
+    assert fmg_total_weighted_hashes == g_total_weighted_hashes == set([73489])

--- a/src/python/tests/test_multigather.py
+++ b/src/python/tests/test_multigather.py
@@ -1098,12 +1098,10 @@ def test_nonindexed_full_vs_sourmash_gather(runtmp):
     g_std_abund =  set([round(x,4) for x in sourmash_gather_df['std_abund']])
     assert fmg_std_abund== g_std_abund == set([3.172, 5.6446, 6.9322])
 
-    # we can't get match filename in FMG yet.
-    # fmg_match_filename =  set(gather_df['match_filename'])
-    # assert fmg_match_filename == [] all are nans rn..{nan, nan, nan}
-    g_match_filename =  sourmash_gather_df['filename']
     g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
-    assert all([x in g_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+    fmg_match_filename_basename = [os.path.basename(filename) for filename in gather_df['match_filename']]
+    assert all([x in fmg_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+    assert fmg_match_filename_basename == g_match_filename_basename
 
     assert list(sourmash_gather_df['name']) == list(gather_df['match_name'])
     assert list(sourmash_gather_df['md5']) == list(gather_df['match_md5'])

--- a/src/python/tests/test_multigather.py
+++ b/src/python/tests/test_multigather.py
@@ -82,7 +82,7 @@ def test_simple(runtmp, zip_against):
     print(df)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp', 'gather_result_rank'}.issubset(keys)
 
 
 def test_simple_space_in_signame(runtmp):
@@ -156,7 +156,7 @@ def test_simple_zip_query(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp', 'gather_result_rank'}.issubset(keys)
 
 
 def test_simple_read_manifests(runtmp):
@@ -199,7 +199,7 @@ def test_simple_read_manifests(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp', 'gather_result_rank'}.issubset(keys)
 
 
 @pytest.mark.parametrize('zip_query', [False, True])
@@ -343,7 +343,7 @@ def test_sig_query(runtmp, capfd, indexed):
     if indexed:
         assert {'query_name', 'query_md5', 'match_name', 'match_md5', 'f_match', 'intersect_bp'}.issubset(keys)
     else:
-        assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}.issubset(keys)
+        assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
 
 
 @pytest.mark.parametrize('indexed', [False, True])
@@ -474,14 +474,14 @@ def test_sig_against(runtmp, capfd):
     df = pandas.read_csv(p_output)
     assert len(df) == 1
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp'}.issubset(keys)
 
     # check gather output
     assert os.path.exists(g_output)
     df = pandas.read_csv(g_output)
     assert len(df) == 1
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp', 'gather_result_rank'}.issubset(keys)
 
 
 def test_bad_against(runtmp, capfd):
@@ -624,7 +624,7 @@ def test_md5(runtmp, zip_query):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp'}.issubset(keys)
 
     md5s = set(df['match_md5'])
     for against_file in (sig2, sig47, sig63):
@@ -715,13 +715,14 @@ def test_csv_columns_vs_sourmash_prefetch(runtmp, zip_query, zip_against):
 
     gather_df = pandas.read_csv(g_output)
     g_keys = set(gather_df.keys())
-    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}.issubset(g_keys)
-    g_keys.remove('rank')       # 'rank' is not in sourmash prefetch!
+    assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(g_keys)
+    g_keys.remove('gather_result_rank')       # 'rank' is not in sourmash prefetch!
 
     sourmash_prefetch_df = pandas.read_csv(sp_output)
     sp_keys = set(sourmash_prefetch_df.keys())
     print(g_keys - sp_keys)
-    assert not g_keys - sp_keys, g_keys - sp_keys
+    diff_keys = g_keys - sp_keys
+    assert diff_keys == set(['remaining_bp', 'f_match_orig', 'f_unique_weighted', 'average_abund', 'unique_intersect_bp', 'std_abund', 'sum_weighted_found', 'median_abund', 'n_unique_weighted_found', 'f_unique_to_query', 'f_orig_query', 'total_weighted_hashes', 'f_match'])
 
 def test_csv_columns_vs_sourmash_gather_fullresults(runtmp):
     # the column names should be identical to sourmash gather cols
@@ -739,7 +740,7 @@ def test_csv_columns_vs_sourmash_gather_fullresults(runtmp):
     g_output = runtmp.output('SRR606249.gather.csv')
     runtmp.sourmash('scripts', 'fastmultigather', query_list,
                     against_list, '-s', '100000', '-t', '0',
-                    '--full-results') # '-o', g_output,
+                    ) # '-o', g_output,
 
     assert os.path.exists(g_output)
     # now run sourmash gather
@@ -831,7 +832,7 @@ def test_simple_protein(runtmp):
         df = pandas.read_csv(g_output)
         assert len(df) == 1
         keys = set(df.keys())
-        assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+        assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp', 'gather_result_rank'}.issubset(keys)
         print(df)
         # since we're just matching to identical sigs, the md5s should be the same
         assert df['query_md5'][0] == df['match_md5'][0]
@@ -856,7 +857,7 @@ def test_simple_dayhoff(runtmp):
         df = pandas.read_csv(g_output)
         assert len(df) == 1
         keys = set(df.keys())
-        assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+        assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp', 'gather_result_rank'}.issubset(keys)
         print(df)
         # since we're just matching to identical sigs, the md5s should be the same
         assert df['query_md5'][0] == df['match_md5'][0]
@@ -881,7 +882,7 @@ def test_simple_hp(runtmp):
         df = pandas.read_csv(g_output)
         assert len(df) == 1
         keys = set(df.keys())
-        assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
+        assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp', 'gather_result_rank'}.issubset(keys)
         print(df)
         # since we're just matching to identical sigs, the md5s should be the same
         assert df['query_md5'][0] == df['match_md5'][0]
@@ -1039,8 +1040,7 @@ def test_nonindexed_full_vs_sourmash_gather(runtmp):
 
     g_output = runtmp.output('SRR606249.gather.csv')
     runtmp.sourmash('scripts', 'fastmultigather', query_list,
-                    against_list, '-s', '100000', '-t', '0',
-                    '--full-results')
+                    against_list, '-s', '100000', '-t', '0')
 
     print(runtmp.last_result.out)
     print(runtmp.last_result.err)
@@ -1125,7 +1125,7 @@ def test_nonindexed_full_vs_sourmash_gather(runtmp):
 
     fmg_query_containment_ani = set([round(x,4) for x in gather_df['query_containment_ani']])
     g_query_containment_ani = set([round(x,4) for x in sourmash_gather_df['query_containment_ani']])
-    assert fmg_query_containment_ani == set([0.8632, 0.8444, 0.8391])
+    assert fmg_query_containment_ani == set([0.8632, 0.8442, 0.8387])
     # gather cANI are nans here -- perhaps b/c sketches too small
     # assert fmg_query_containment_ani == g_query_containment_ani == set([0.8632, 0.8444, 0.8391])
     print("fmg qcANI: ", fmg_query_containment_ani)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -899,7 +899,6 @@ pub fn branchwater_calculate_gather_stats(
         median_abund,
         std_abund,
         match_filename,
-        // match_filename: "".to_string(), // how to get match filename??
         match_name,
         match_md5,
         f_match_orig,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -824,7 +824,7 @@ pub fn branchwater_calculate_gather_stats(
     // stats for this match vs current (subtracted) query
     let f_match = match_size as f64 / match_mh.size() as f64;
     let unique_intersect_bp = match_mh.scaled() as usize * match_size;
-    let f_unique_to_query = match_size as f64 / query.size() as f64;
+    let f_unique_to_query = match_size as f64 / orig_query.size() as f64;
 
     // // get ANI values
     let ksize = match_mh.ksize() as f64;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -960,7 +960,7 @@ pub fn consume_query_by_gather(
 
     let orig_query_mh = query.minhash().unwrap();
     let mut query_mh = orig_query_mh.clone();
-    let orig_query_ds = orig_query_mh.clone();
+    let mut orig_query_ds = orig_query_mh.clone();
     // to do == use this to subtract hashes instead
     // let mut query_mht = KmerMinHashBTree::from(orig_query_mh.clone());
 
@@ -986,6 +986,9 @@ pub fn consume_query_by_gather(
 
     while !matching_sketches.is_empty() {
         let best_element = matching_sketches.peek().unwrap();
+
+        query_mh = query_mh.downsample_scaled(best_element.minhash.scaled())?;
+        orig_query_ds = orig_query_ds.downsample_scaled(best_element.minhash.scaled())?;
 
         if make_full_result {
             //calculate full gather stats here

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -956,8 +956,7 @@ pub fn consume_query_by_gather(
 
     let mut last_matches = matching_sketches.len();
 
-    // let location = query.location;
-    let location = query.filename(); // this is different (original fasta filename) than query.location was (sig name)!!
+    let location = query.filename();
 
     let orig_query_mh = query.minhash().unwrap();
     let mut query_mh = orig_query_mh.clone();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,6 +39,7 @@ pub struct SmallSignature {
 pub struct PrefetchResult {
     pub name: String,
     pub md5sum: String,
+    pub location: String,
     pub minhash: KmerMinHash,
     pub overlap: u64,
 }
@@ -481,7 +482,7 @@ pub fn load_sketches_above_threshold(
                                 name: against_record.name().to_string(),
                                 md5sum: against_mh.md5sum(),
                                 minhash: against_mh_ds.clone(),
-                                // filename: against_record.filename(),
+                                location: against_record.internal_location().to_string(),
                                 overlap,
                             };
                             results.push(result);
@@ -803,6 +804,7 @@ pub fn branchwater_calculate_gather_stats(
     match_name: String,
     match_md5: String,
     match_size: usize,
+    match_filename: String,
     gather_result_rank: usize,
     sum_weighted_found: usize,
     total_weighted_hashes: usize,
@@ -896,8 +898,8 @@ pub fn branchwater_calculate_gather_stats(
         average_abund,
         median_abund,
         std_abund,
-        // match_filename,
-        match_filename: "".to_string(), // how to get match filename??
+        match_filename,
+        // match_filename: "".to_string(), // how to get match filename??
         match_name,
         match_md5,
         f_match_orig,
@@ -997,6 +999,7 @@ pub fn consume_query_by_gather(
                 best_element.name.clone(),
                 best_element.md5sum.clone(),
                 best_element.overlap.clone() as usize,
+                best_element.location.clone(),
                 rank,
                 sum_weighted_found,
                 total_weighted_hashes.try_into().unwrap(),


### PR DESCRIPTION
This PR adds utilities for building full gather results file for `fastgather` and non-rocksdb `fastmultigather`, and makes full output default.

- Fixes #287 
- Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/187
- Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/254
- includes a local fix for https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/318, which means that the `fastgather` and **non-rocksdb** `fastmultigather` full output here matches sourmash gather. Issues with rocksdb gather are being handled elsewhere.

## Benchmarking

| software/version | command | details | time | max RAM |
| -------- | -------- | -------- | -- | -- |
| branchwater v0.9.3 | `fastgather` | minimal result | <span style="color:green">**1m 47s**</span> | <span style="color:black">**14 GB**</span> |
| branchwater v0.9.3-dev | `fastgather` | full result | <span style="color:green">**1m 57s**</span> | <span style="color:black">**14 GB**</span> |
| branchwater v0.9.3 | `fastmultigather` | minimal result | <span style="color:red">**8m 3s**</span> | <span style="color:black">**25 GB**</span> |
| branchwater v0.9.3-dev | `fastmultigather` | full result | <span style="color:red">**8m 9s**</span> | <span style="color:black">**25 GB**</span> |
| branchwater v0.9.3 | `fastmultigather` | rocksdb full result | <span style="color:green">**24s**</span> | <span style="color:green">**600 MB**</span> |

progress/separate PRs:
- [x] Fill out `match_filename` in full results (https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/303; requires new sourmash core release with https://github.com/sourmash-bio/sourmash/pull/3121)
- [x] switch to using `KmerMinHashBTree` for hash subtraction +benchmark. Per luiz, `KmerMinHashBTree` are better for any situation where we'll be subtracting/adding hashes to a sketch https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/310
- [x] sourmash: make getting `Record`.filename public in order to keep match_filename and write it to full results. (https://github.com/sourmash-bio/sourmash/pull/3121)
- [x] remove --full-results and make full results default #327 