### PR TITLE
fill out `match_filename` in the non-rocksdb full-result gathers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,9 +482,9 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -627,9 +627,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "histogram"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b634390eb8a63662e127836d4e2f26d7ae930600d4e05ee0fd85a009eeb1175"
+checksum = "f4d3bddd75a32b17e75762f128ffc7a33158b933b6eb27424da9be4a58f30eb9"
 dependencies = [
  "thiserror",
 ]
@@ -1677,8 +1677,7 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 [[package]]
 name = "sourmash"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084cf7e17f32408757d20fea1b6c09ed3dafdac4b894302e29906b51e0eac739"
+source = "git+https://github.com/sourmash-bio/sourmash?branch=latest#c205057deb67cc8730a72ce2d58f442a6e70edfd"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.20.3", features = ["extension-module", "anyhow"] }
 rayon = "1.10.0"
 serde = { version = "1.0.196", features = ["derive"] }
-sourmash = { version = "0.13.1", features = ["branchwater"] }
+# sourmash = { version = "0.13.1", features = ["branchwater"] }
+sourmash = { git = "https://github.com/sourmash-bio/sourmash", branch = "latest", features = ["branchwater"] }
 serde_json = "1.0.115"
 niffler = "2.4.0"
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.20.3", features = ["extension-module", "anyhow"] }
 rayon = "1.10.0"
 serde = { version = "1.0.196", features = ["derive"] }
-# sourmash = { version = "0.13.1", features = ["branchwater"] }
-sourmash = { git = "https://github.com/sourmash-bio/sourmash", branch = "latest", features = ["branchwater"] }
+sourmash = { version = "0.13.1", features = ["branchwater"] }
 serde_json = "1.0.115"
 niffler = "2.4.0"
 log = "0.4.14"

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -81,6 +81,7 @@ pub fn fastmultigather(
                                         name: against.name.clone(),
                                         md5sum: against.md5sum.clone(),
                                         minhash: against.minhash.clone(),
+                                        filename: against.location.clone(),
                                         overlap,
                                     };
                                     mm = Some(result);

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -81,7 +81,7 @@ pub fn fastmultigather(
                                         name: against.name.clone(),
                                         md5sum: against.md5sum.clone(),
                                         minhash: against.minhash.clone(),
-                                        filename: against.location.clone(),
+                                        location: against.location.clone(),
                                         overlap,
                                     };
                                     mm = Some(result);

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -810,18 +810,10 @@ def test_fullres_vs_sourmash_gather(runtmp):
     g_std_abund =  set([round(x,4) for x in sourmash_gather_df['std_abund']])
     assert fg_std_abund== g_std_abund == set([3.172, 5.6446, 6.9322])
 
-    # record.filename() is actually the fasta filename, not the sig filename...
-    fg_match_filename =  set(gather_df['match_filename'])
-    print(f"match_filename: {fg_match_filename}")
-#   fg_match_filename: {'podar-ref/47.fa', 'podar-ref/63.fa', 'podar-ref/2.fa'}
-    g_match_filename =  sourmash_gather_df['filename']
     g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
-    assert all([x in g_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
-
-    # g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
-    # fg_match_filename_basename = [os.path.basename(filename) for filename in gather_df['match_filename']]
-    # assert all([x in fg_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
-    # assert fg_match_filename_basename == g_match_filename_basename
+    fg_match_filename_basename = [os.path.basename(filename) for filename in gather_df['match_filename']]
+    assert all([x in fg_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+    assert fg_match_filename_basename == g_match_filename_basename
 
     assert list(sourmash_gather_df['name']) == list(gather_df['match_name'])
     assert list(sourmash_gather_df['md5']) == list(gather_df['match_md5'])

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -810,12 +810,18 @@ def test_fullres_vs_sourmash_gather(runtmp):
     g_std_abund =  set([round(x,4) for x in sourmash_gather_df['std_abund']])
     assert fg_std_abund== g_std_abund == set([3.172, 5.6446, 6.9322])
 
-    # we can't get match filename in FG yet.
-    # fg_match_filename =  set(gather_df['match_filename'])
-    # assert fg_match_filename == [] all are nans rn..{nan, nan, nan}
+    # record.filename() is actually the fasta filename, not the sig filename...
+    fg_match_filename =  set(gather_df['match_filename'])
+    print(f"match_filename: {fg_match_filename}")
+#   fg_match_filename: {'podar-ref/47.fa', 'podar-ref/63.fa', 'podar-ref/2.fa'}
     g_match_filename =  sourmash_gather_df['filename']
     g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
     assert all([x in g_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+
+    # g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
+    # fg_match_filename_basename = [os.path.basename(filename) for filename in gather_df['match_filename']]
+    # assert all([x in fg_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+    # assert fg_match_filename_basename == g_match_filename_basename
 
     assert list(sourmash_gather_df['name']) == list(gather_df['match_name'])
     assert list(sourmash_gather_df['md5']) == list(gather_df['match_md5'])

--- a/src/python/tests/test_multigather.py
+++ b/src/python/tests/test_multigather.py
@@ -1098,12 +1098,10 @@ def test_nonindexed_full_vs_sourmash_gather(runtmp):
     g_std_abund =  set([round(x,4) for x in sourmash_gather_df['std_abund']])
     assert fmg_std_abund== g_std_abund == set([3.172, 5.6446, 6.9322])
 
-    # we can't get match filename in FMG yet.
-    # fmg_match_filename =  set(gather_df['match_filename'])
-    # assert fmg_match_filename == [] all are nans rn..{nan, nan, nan}
-    g_match_filename =  sourmash_gather_df['filename']
     g_match_filename_basename = [os.path.basename(filename) for filename in sourmash_gather_df['filename']]
-    assert all([x in g_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+    fmg_match_filename_basename = [os.path.basename(filename) for filename in gather_df['match_filename']]
+    assert all([x in fmg_match_filename_basename for x in ['2.fa.sig.gz', '63.fa.sig.gz', '47.fa.sig.gz']])
+    assert fmg_match_filename_basename == g_match_filename_basename
 
     assert list(sourmash_gather_df['name']) == list(gather_df['match_name'])
     assert list(sourmash_gather_df['md5']) == list(gather_df['match_md5'])

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,7 +39,7 @@ pub struct SmallSignature {
 pub struct PrefetchResult {
     pub name: String,
     pub md5sum: String,
-    pub filename: String,
+    pub location: String,
     pub minhash: KmerMinHash,
     pub overlap: u64,
 }
@@ -482,8 +482,7 @@ pub fn load_sketches_above_threshold(
                                 name: against_record.name().to_string(),
                                 md5sum: against_mh.md5sum(),
                                 minhash: against_mh_ds.clone(),
-                                // this turns out to be the FASTA filename, not the sig filename...
-                                filename: against_record.filename().to_string(),
+                                location: against_record.internal_location().to_string(),
                                 overlap,
                             };
                             results.push(result);
@@ -1000,7 +999,7 @@ pub fn consume_query_by_gather(
                 best_element.name.clone(),
                 best_element.md5sum.clone(),
                 best_element.overlap.clone() as usize,
-                best_element.filename.clone(),
+                best_element.location.clone(),
                 rank,
                 sum_weighted_found,
                 total_weighted_hashes.try_into().unwrap(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,6 +39,7 @@ pub struct SmallSignature {
 pub struct PrefetchResult {
     pub name: String,
     pub md5sum: String,
+    pub filename: String,
     pub minhash: KmerMinHash,
     pub overlap: u64,
 }
@@ -481,7 +482,8 @@ pub fn load_sketches_above_threshold(
                                 name: against_record.name().to_string(),
                                 md5sum: against_mh.md5sum(),
                                 minhash: against_mh_ds.clone(),
-                                // filename: against_record.filename(),
+                                // this turns out to be the FASTA filename, not the sig filename...
+                                filename: against_record.filename().to_string(),
                                 overlap,
                             };
                             results.push(result);
@@ -803,6 +805,7 @@ pub fn branchwater_calculate_gather_stats(
     match_name: String,
     match_md5: String,
     match_size: usize,
+    match_filename: String,
     gather_result_rank: usize,
     sum_weighted_found: usize,
     total_weighted_hashes: usize,
@@ -896,8 +899,8 @@ pub fn branchwater_calculate_gather_stats(
         average_abund,
         median_abund,
         std_abund,
-        // match_filename,
-        match_filename: "".to_string(), // how to get match filename??
+        match_filename,
+        // match_filename: "".to_string(), // how to get match filename??
         match_name,
         match_md5,
         f_match_orig,
@@ -997,6 +1000,7 @@ pub fn consume_query_by_gather(
                 best_element.name.clone(),
                 best_element.md5sum.clone(),
                 best_element.overlap.clone() as usize,
+                best_element.filename.clone(),
                 rank,
                 sum_weighted_found,
                 total_weighted_hashes.try_into().unwrap(),


### PR DESCRIPTION
fixes #303 

Actually, we didn't need https://github.com/sourmash-bio/sourmash/pull/3121 after all. I didn't realize that `Record.filename` is the originating FASTA filename, not the signature location. To match sourmash gather output, we just need the `location`/`internal_location`.