### PR TITLE
MRG: fix lint error, & processed sig reporting for rocksdb/fastmultigather

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,14 +12,17 @@ jobs:
         fetch-depth: 0
 
     - name: Install latest stable rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: actions-rs/toolchain@v1
       with:
          toolchain: stable
          override: true
          components: rustfmt, clippy
 
     - name: Run cargo fmt
-      run: cargo fmt --all -- --check
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
 
     - name: cache rust
       uses: Swatinem/rust-cache@v2
@@ -27,7 +30,7 @@ jobs:
     - name: cache conda
       uses: actions/cache@v4
       env:
-        CACHE_NUMBER: 1
+        CACHE_NUMBER: 0
       with:
         path: ~/conda_pkgs_dir
         key:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,9 +19,7 @@ jobs:
          components: rustfmt, clippy
 
     - name: Run cargo fmt
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
 
     - name: cache rust
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,14 +12,13 @@ jobs:
         fetch-depth: 0
 
     - name: Install latest stable rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain
       with:
          toolchain: stable
          override: true
          components: rustfmt, clippy
 
     - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
       with:
         command: fmt
         args: --all -- --check

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: cache conda
       uses: actions/cache@v4
       env:
-        CACHE_NUMBER: 0
+        CACHE_NUMBER: 1
       with:
         path: ~/conda_pkgs_dir
         key:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install latest stable rust
-      uses: dtolnay/rust-toolchain
+      uses: dtolnay/rust-toolchain@stable
       with:
          toolchain: stable
          override: true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,9 @@ fn do_fastmultigather(
             }
         }
     } else {
+        if let Some(_) = output_path {
+            bail!("output path specified, but not running fastmultigather against a rocksdb. See issue #239");
+        }
         match fastmultigather::fastmultigather(
             query_filenames,
             siglist_path,

--- a/src/mastiff_manygather.rs
+++ b/src/mastiff_manygather.rs
@@ -62,6 +62,7 @@ pub fn mastiff_manygather(
                 Ok(query_sig) => {
                     let mut results = vec![];
                     if let Some(query_mh) = query_sig.minhash() {
+                        let _ = processed_sigs.fetch_add(1, atomic::Ordering::SeqCst);
                         // Gather!
                         let (counter, query_colors, hash_to_color) =
                             db.prepare_gather_counters(query_mh);

--- a/src/python/tests/test_multigather.py
+++ b/src/python/tests/test_multigather.py
@@ -172,7 +172,7 @@ def test_simple_read_manifests(runtmp):
 
     make_file_list(against_list, [sig2, sig47, sig63])
 
-    runtmp.sourmash("sig","manifest", query, "-o", query_mf)
+    runtmp.sourmash("sig", "manifest", query, "-o", query_mf)
     runtmp.sourmash("sig", "manifest", against_list, "-o", against_mf)
 
     cwd = os.getcwd()
@@ -316,12 +316,14 @@ def test_sig_query(runtmp, capfd, indexed):
     if indexed:
         against_list = index_siglist(runtmp, against_list, runtmp.output('db'))
         g_output = runtmp.output('out.csv')
+        output_params = ['-o', g_output]
     else:
         g_output = runtmp.output('SRR606249.gather.csv')
         p_output = runtmp.output('SRR606249.prefetch.csv')
+        output_params = []
 
     runtmp.sourmash('scripts', 'fastmultigather', query, against_list,
-                        '-s', '100000', '-o', g_output)
+                        '-s', '100000', *output_params)
 
     captured = capfd.readouterr()
     print(captured.err)
@@ -361,14 +363,11 @@ def test_bad_query(runtmp, capfd, indexed):
 
     make_file_list(against_list, [sig2, sig47, sig63])
 
-    output = runtmp.output('out.csv')
-
     if indexed:
         against_list = index_siglist(runtmp, against_list, runtmp.output('db'))
 
     with pytest.raises(utils.SourmashCommandFailed):
-        runtmp.sourmash('scripts', 'fastmultigather', query_zip, against_list,
-                        '-o', output)
+        runtmp.sourmash('scripts', 'fastmultigather', query_zip, against_list)
 
     captured = capfd.readouterr()
     print(captured.err)
@@ -520,13 +519,12 @@ def test_bad_against_2(runtmp, capfd, zip_query):
         with open(sig2, 'rb') as fp2:
             fp.write(fp2.read())
 
-    output = runtmp.output('out.csv')
     if zip_query:
         query_list = zip_siglist(runtmp, query_list, runtmp.output('query.zip'))
 
     with pytest.raises(utils.SourmashCommandFailed):
         runtmp.sourmash('scripts', 'fastmultigather', query_list, against_zip,
-                        '-s', '100000', '-o', output)
+                        '-s', '100000')
 
     captured = capfd.readouterr()
     print(captured.err)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -432,7 +432,7 @@ fn process_prefix_csv(
 pub fn load_sketches(
     collection: Collection,
     selection: &Selection,
-    report_type: ReportType,
+    _report_type: ReportType,
 ) -> Result<Vec<SmallSignature>> {
     let sketchinfo: Vec<SmallSignature> = collection
         .par_iter()


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/313
Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/285

Addresses #239 / #299 by bailing out when an output path is provided but will not be used:
```
RuntimeError: output path specified, but not running fastmultigather against a rocksdb. See 
issue #239
```
although we are leaning towards respecting `-o` in the future, see #299 discussion, so this will soon get revisited.