### PR TITLE
MRG: fix CI build & tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,7 @@ jobs:
         mamba-version: "*"
         activate-environment: sourmash_dev
         auto-activate-base: false
-        use-only-tar-bz2: true
+#        use-only-tar-bz2: true
 
     - run: conda info
     - run: conda list

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,7 +39,11 @@ jobs:
 
     - name: install dependencies
       shell: bash -l {0}
-      run: mamba install git compilers maturin pytest pandas rust==1.75.0
+      run: mamba install rust==1.75.0
+
+    - name: install dependencies 2
+      shell: bash -l {0}
+      run: mamba install compilers maturin pytest pandas
 
     - name: Run cargo fmt
       run: cargo fmt --all -- --check --verbose

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: cache conda
       uses: actions/cache@v4
       env:
-        CACHE_NUMBER: 0
+        CACHE_NUMBER: 1
       with:
         path: ~/conda_pkgs_dir
         key:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,19 +11,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install latest stable rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-         toolchain: stable
-         override: true
-         components: rustfmt, clippy
-
-    - name: Run cargo fmt
-      run: cargo fmt --all -- --check --verbose
-
-    - name: cache rust
-      uses: Swatinem/rust-cache@v2
-
     - name: cache conda
       uses: actions/cache@v4
       env:
@@ -32,6 +19,9 @@ jobs:
         path: ~/conda_pkgs_dir
         key:
           ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
+
+    - name: cache rust
+      uses: Swatinem/rust-cache@v2
 
     - name: setup conda
       uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca
@@ -49,7 +39,10 @@ jobs:
 
     - name: install dependencies
       shell: bash -l {0}
-      run: mamba install git compilers maturin pytest pandas crossenv libclang clangdev
+      run: mamba install git compilers maturin pytest pandas rust
+
+    - name: Run cargo fmt
+      run: cargo fmt --all -- --check --verbose
 
     - name: build
       shell: bash -l {0}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,10 +24,10 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: setup conda
-      uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca
+      uses: conda-incubator/setup-miniconda@3
       with:
         auto-update-conda: true
-        python-version: 3.11
+        python-version: 3.12
         channels: conda-forge,bioconda
         miniforge-variant: Mambaforge
         miniforge-version: latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: setup conda
-      uses: conda-incubator/setup-miniconda@3
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: 3.12

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,6 +37,12 @@ jobs:
         auto-activate-base: false
         use-only-tar-bz2: true
 
+    - run: conda info
+    - run: conda list
+    - run: conda config --show
+
+    - run: mamba search rust
+
     - name: install dependencies
       shell: bash -l {0}
       run: mamba install rust==1.75.0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,17 +12,14 @@ jobs:
         fetch-depth: 0
 
     - name: Install latest stable rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
          toolchain: stable
          override: true
          components: rustfmt, clippy
 
     - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check --verbose --message-format=human
 
     - name: cache rust
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: install dependencies
       shell: bash -l {0}
-      run: mamba install git compilers maturin pytest pandas rust
+      run: mamba install git compilers maturin pytest pandas rust==1.75.0
 
     - name: Run cargo fmt
       run: cargo fmt --all -- --check --verbose

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: install dependencies
       shell: bash -l {0}
-      run: mamba install git compilers maturin pytest pandas
+      run: mamba install git compilers maturin pytest pandas crossenv libclang clangdev
 
     - name: build
       shell: bash -l {0}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
          components: rustfmt, clippy
 
     - name: Run cargo fmt
-      run: cargo fmt --all -- --check --verbose --message-format=human
+      run: cargo fmt --all -- --check --verbose
 
     - name: cache rust
       uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ sourmash = { version = "0.13.1", features = ["branchwater"] }
 serde_json = "1.0.116"
 niffler = "2.4.0"
 log = "0.4.14"
-env_logger = "0.11.3"
+env_logger = { version = "0.11.3", optional = true }
 simple-error = "0.3.0"
 anyhow = "1.0.82"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ tempfile = "3.10.0"
 
 [profile.release]
 #target-cpu=native
-lto = "thin"
+#lto = "thin"
 opt-level = 3


### PR DESCRIPTION
Fix broken CI. Among other things,`actions-rs` is unmaintained per https://github.com/actions-rs/toolchain/issues/216. I think the original breakage might have been occasioned by the runner image for ubuntu-latest being updated about two weeks ago ([link](https://github.com/actions/runner-images/blob/ubuntu22/20240422.1/images/ubuntu/Ubuntu2204-Readme.md)).

A laundry list of problems to fix seems to have boiled down to:
* don't mix rustup installs with conda installs;
* if you're going to use conda-incubator/setup-miniconda, do not set `use-only-tar-bz2` to true (https://github.com/conda-incubator/setup-miniconda/issues/267#issuecomment-2102569634)

Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/321
