### PR TITLE
MRG: add `dayhoff`/`hp` sketching improvements from `directsketch`

### DIFF
--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -68,6 +68,13 @@ fn parse_params_str(params_strs: String) -> Result<Vec<Params>, String> {
             }
         }
 
+        if !is_dna && !is_protein && !is_dayhoff && !is_hp {
+            return Err(format!("No moltype provided in params string {}", p_str));
+        }
+        if ksizes.is_empty() {
+            return Err(format!("No ksizes provided in params string {}", p_str));
+        }
+
         for &k in &ksizes {
             let param = Params {
                 ksize: k,

--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -349,7 +349,7 @@ class Branchwater_Manysketch(CommandLinePlugin):
     def main(self, args):
         print_version()
         if not args.param_string:
-            args.param_string = ["k=31,scaled=1000"]
+            args.param_string = ["dna,k=31,scaled=1000"]
         notify(f"params: {args.param_string}")
 
         # convert to a single string for easier rust handling

--- a/src/python/tests/test_sketch.py
+++ b/src/python/tests/test_sketch.py
@@ -338,7 +338,7 @@ def test_manysketch_bad_fa_csv_3(runtmp, capfd):
     assert "Could not load fromfile csv" in captured.err
 
 
-def test_manysketch_bad_fa_csv_3(runtmp, capfd):
+def test_manysketch_bad_fa_csv_4(runtmp, capfd):
     # test sketch with improperly formatted fa_csv
     fa_csv = runtmp.output('db-fa.csv')
 
@@ -371,7 +371,48 @@ def test_manysketch_bad_fa_csv_3(runtmp, capfd):
     print(captured.err)
     assert 'found record with 2 fields' in captured.err
     assert "Could not load fromfile csv" in captured.err
- 
+
+
+def test_manysketch_bad_param_str_moltype(runtmp, capfd):
+    # no moltype provided in param str
+    fa_csv = runtmp.output('db-fa.txt')
+
+    fa1 = get_test_data('short.fa')
+    fa2 = get_test_data('short2.fa')
+    fa3 = get_test_data('short3.fa')
+
+    make_assembly_csv(fa_csv, [fa1, fa2, fa3])
+    output = runtmp.output('out.zip')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'manysketch', fa_csv,
+                        '-o', output, '-p', 'k=31,scaled=100')
+
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert "Error parsing params string: No moltype provided in params string k=31,scaled=100" in captured.err
+    assert "Failed to parse params string" in captured.err
+
+
+def test_manysketch_bad_param_str_ksize(runtmp, capfd):
+    # no ksize provided in param str
+    fa_csv = runtmp.output('db-fa.txt')
+
+    fa1 = get_test_data('short.fa')
+    fa2 = get_test_data('short2.fa')
+    fa3 = get_test_data('short3.fa')
+
+    make_assembly_csv(fa_csv, [fa1, fa2, fa3])
+    output = runtmp.output('out.zip')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'manysketch', fa_csv,
+                        '-o', output, '-p', 'dna,scaled=100')
+
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert "Error parsing params string: No ksizes provided in params string dna,scaled=100" in captured.err
+    assert "Failed to parse params string" in captured.err
 
 def test_manysketch_empty_fa_csv(runtmp, capfd):
     # test empty fa_csv file

--- a/src/python/tests/test_sketch.py
+++ b/src/python/tests/test_sketch.py
@@ -171,6 +171,7 @@ def test_manysketch_mult_moltype(runtmp):
             assert sig.minhash.is_dna
             assert sig.md5sum() in ["4efeebd26644278e36b9553e018a851a","f85747ac4f473c4a71c1740d009f512b"]
 
+
 def test_manysketch_mult_moltype_protein(runtmp):
     fa_csv = runtmp.output('db-fa.csv')
 
@@ -193,24 +194,17 @@ def test_manysketch_mult_moltype_protein(runtmp):
 
     assert len(sigs) == 2
     # check moltypes, etc!
+    total_checked = 0
     for sig in sigs:
-        if sig.name == 'short':
-            if sig.minhash.is_dna:
-                assert sig.minhash.ksize == 21
-                assert sig.minhash.scaled == 1
-                assert sig.md5sum() == "1474578c5c46dd09da4c2df29cf86621"
-            else:
-                assert sig.name == 'short'
-                assert sig.minhash.ksize == 10
-                assert sig.minhash.scaled == 1
-                assert sig.md5sum() == "eb4467d11e0ecd2dbde4193bfc255310"
-        else:
-            assert sig.name in ['short', 'short2', 'short3']
-            assert sig.minhash.ksize == 21
-            assert sig.minhash.scaled == 1
-            assert sig.minhash.is_dna
-            assert sig.md5sum() in ["4efeebd26644278e36b9553e018a851a","f85747ac4f473c4a71c1740d009f512b"]
-
+        print(sig.name)
+        assert sig.name == "short-protein"
+        if sig.minhash.dayhoff:
+            assert sig.md5sum() == "320464775fe704d9f938a8c63d8dd722"
+            total_checked+=1
+        elif sig.minhash.hp:
+            assert sig.md5sum() == "e8ccc6ca7ad560072f51be631d1c39c0"
+            total_checked+=1
+    assert total_checked == 2
 
 
 def test_manysketch_only_incompatible_fastas(runtmp, capfd):

--- a/src/python/tests/test_sketch.py
+++ b/src/python/tests/test_sketch.py
@@ -305,6 +305,24 @@ def test_manysketch_bad_fa_csv(runtmp, capfd):
 
 
 def test_manysketch_bad_fa_csv_2(runtmp, capfd):
+    # bad file within filelist
+    siglist = runtmp.output('bad.txt')
+
+    # fa_file = runtmp.output("bad.fa")
+    make_assembly_csv(siglist, ["bad2.fa"])
+
+    output = runtmp.output('db.zip')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'manysketch', siglist, '-o', output)
+
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert "Could not load fasta files: no signatures created." in captured.err
+    assert "Error opening file bad2.fa: ParseError" in captured.err
+
+
+def test_manysketch_bad_fa_csv_3(runtmp, capfd):
     # test sketch with fasta provided instead of fa_csv
     output = runtmp.output('out.zip')
     fa1 = get_test_data('short.fa')

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,6 +26,7 @@ use sourmash::sketch::minhash::KmerMinHash;
 use sourmash::storage::{FSStorage, InnerStorage, SigStore};
 use stats::{median, stddev};
 use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 /// Track a name/minhash.
 
 pub struct SmallSignature {
@@ -1247,10 +1248,10 @@ pub struct Params {
     pub scaled: u64,
     pub seed: u32,
     pub is_protein: bool,
+    pub is_dayhoff: bool,
+    pub is_hp: bool,
     pub is_dna: bool,
 }
-use std::hash::Hash;
-use std::hash::Hasher;
 
 impl Hash for Params {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -1260,6 +1261,8 @@ impl Hash for Params {
         self.scaled.hash(state);
         self.seed.hash(state);
         self.is_protein.hash(state);
+        self.is_dayhoff.hash(state);
+        self.is_hp.hash(state);
         self.is_dna.hash(state);
     }
 }


### PR DESCRIPTION
- fixes `dayhoff`, `hp` param parsing and sig template building
- based on changes in https://github.com/sourmash-bio/sourmash_plugin_directsketch/pull/55
- also adds some checks for moltype, ksizes in param str, since those are not set by default in the `parse_param_str` function.