### PR TITLE
MRG: update ReportType string output

### DIFF
--- a/src/python/tests/test_pairwise.py
+++ b/src/python/tests/test_pairwise.py
@@ -221,7 +221,7 @@ def test_bad_query(runtmp, capfd):
     print(captured.err)
 
     assert "WARNING: could not load sketches from path 'no-exist'" in captured.err
-    assert "WARNING: 1 signature paths failed to load. See error messages above." in captured.err
+    assert "WARNING: 1 analysis paths failed to load. See error messages above." in captured.err
 
 
 def test_bad_query_2(runtmp, capfd):
@@ -314,7 +314,7 @@ def test_nomatch_query(runtmp, capfd, zip_query):
     captured = capfd.readouterr()
     print(captured.err)
 
-    assert 'WARNING: skipped 1 signature paths - no compatible signatures' in captured.err
+    assert 'WARNING: skipped 1 analysis paths - no compatible signatures' in captured.err
 
 
 @pytest.mark.parametrize("zip_db", [False, True])

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -529,7 +529,7 @@ impl std::fmt::Display for ReportType {
         let description = match self {
             ReportType::Query => "query",
             ReportType::Against => "search",
-            ReportType::General => "signature",
+            ReportType::General => "analysis",
         };
         write!(f, "{}", description)
     }


### PR DESCRIPTION
I noticed a strange output when running `pairwise`:
```
Loaded 1000 signature signature(s)
```
I was curious about the redundancy and tracked this down to ReportType => string formatting.

I think having this be:

Loaded 1000 analysis signature(s)

makes a bit more sense.

Small change, but 🤷 :)
