### PR TITLE
MRG: update zip crate to 2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
   allow:
     - dependency-type: "direct"
   open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: "zip"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,10 +474,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "doc-comment"
@@ -824,6 +855,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
@@ -1676,6 +1713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,14 +2239,33 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
  "crossbeam-utils",
+ "displaydoc",
  "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,15 +474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,12 +1048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,12 +1190,6 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1927,25 +1906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,7 +2237,6 @@ dependencies = [
  "displaydoc",
  "indexmap",
  "thiserror",
- "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,12 +866,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lockfree-object-pool"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
-
-[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,12 +1728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,34 +2267,17 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+checksum = "fccb210625924ecbbe92f9bb497d04b167b64fe5540cec75f10b16e0c51ee92b"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
- "flate2",
  "indexmap",
- "memchr",
  "thiserror",
  "time",
- "zopfli",
-]
-
-[[package]]
-name = "zopfli"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "lockfree-object-pool",
- "log",
- "once_cell",
- "simd-adler32",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,13 +979,13 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1052,6 +1061,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -1196,6 +1211,12 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1918,6 +1939,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2291,7 @@ dependencies = [
  "indexmap",
  "memchr",
  "thiserror",
+ "time",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ pyo3 = { version = "0.21.2", features = ["extension-module", "anyhow"] }
 rayon = "1.10.0"
 serde = { version = "1.0.204", features = ["derive"] }
 sourmash = { version = "0.14.1", features = ["branchwater"] }
+#sourmash = { git="https://github.com/sourmash-bio/sourmash", branch="lirber/rc-zip", features = ["branchwater"] }
 serde_json = "1.0.120"
 niffler = "2.4.0"
 log = "0.4.22"
 env_logger = { version = "0.11.3", optional = true }
 simple-error = "0.3.1"
 anyhow = "1.0.86"
-zip = { version = "2.1.3", default-features = false, features = ["deflate"] }
+zip = { version = "2.1.3", default-features = false, features = ["deflate", "time"] }
 tempfile = "3.10"
 needletail = "0.5.1"
 csv = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.22"
 env_logger = { version = "0.11.3", optional = true }
 simple-error = "0.3.1"
 anyhow = "1.0.86"
-zip = { version = "2.0", default-features = false, features = ["time"] }
+zip = { version = "2.0", default-features = false }
 tempfile = "3.10"
 needletail = "0.5.1"
 csv = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,13 @@ pyo3 = { version = "0.21.2", features = ["extension-module", "anyhow"] }
 rayon = "1.10.0"
 serde = { version = "1.0.204", features = ["derive"] }
 sourmash = { version = "0.14.1", features = ["branchwater"] }
-#sourmash = { git="https://github.com/sourmash-bio/sourmash", branch="lirber/rc-zip", features = ["branchwater"] }
 serde_json = "1.0.120"
 niffler = "2.4.0"
 log = "0.4.22"
 env_logger = { version = "0.11.3", optional = true }
 simple-error = "0.3.1"
 anyhow = "1.0.86"
-zip = { version = "2.1.3", default-features = false, features = ["deflate", "time"] }
+zip = { version = "2.0", default-features = false, features = ["time"] }
 tempfile = "3.10"
 needletail = "0.5.1"
 csv = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.22"
 env_logger = { version = "0.11.3", optional = true }
 simple-error = "0.3.1"
 anyhow = "1.0.86"
-zip = { version = "0.6", default-features = false, features = ["deflate"] }
+zip = { version = "2.1.3", default-features = false, features = ["deflate"] }
 tempfile = "3.10"
 needletail = "0.5.1"
 csv = "1.3.0"

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -170,7 +170,6 @@ pub fn manysketch(
             let name = &fastadata.name;
             let filenames = &fastadata.paths;
             let moltype = &fastadata.input_type;
-            let mut allsigs = Vec::new();
             // build sig templates for these sketches from params, check if there are sigs to build
             let sig_templates = build_siginfo(&params_vec, moltype);
             // if no sigs to build, skip this iteration
@@ -243,20 +242,26 @@ pub fn manysketch(
                         Err(err) => eprintln!("Error while processing record: {:?}", err),
                     }
                     if singleton {
-                        allsigs.append(&mut sigs);
+                        // write sigs immediately to avoid memory issues
+                        if let Err(e) = send.send(ZipMessage::SignatureData(sigs.clone())) {
+                            eprintln!("Unable to send internal data: {:?}", e);
+                            return None;
+                        }
                         sigs = sig_templates.clone();
                     }
                 }
             }
-            if !singleton {
-                allsigs.append(&mut sigs);
+            // if singleton sketches, they have already been written; only write aggregate sketches
+            if singleton {
+                None
+            } else {
+                Some(sigs)
             }
-            Some(allsigs)
         })
         .try_for_each_with(
             send.clone(),
-            |s: &mut std::sync::Arc<std::sync::mpsc::SyncSender<ZipMessage>>, filled_sigs| {
-                if let Err(e) = s.send(ZipMessage::SignatureData(filled_sigs)) {
+            |s: &mut std::sync::Arc<std::sync::mpsc::SyncSender<ZipMessage>>, sigs| {
+                if let Err(e) = s.send(ZipMessage::SignatureData(sigs)) {
                     Err(format!("Unable to send internal data: {:?}", e))
                 } else {
                     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::panic;
 use std::sync::atomic;
 use std::sync::atomic::AtomicUsize;
-use zip::write::{FileOptions, ZipWriter};
+use zip::write::{ExtendedFileOptions, FileOptions, ZipWriter};
 use zip::CompressionMethod;
 
 use sourmash::ani_utils::{ani_ci_from_containment, ani_from_containment};
@@ -1291,6 +1291,7 @@ pub fn sigwriter(
 
         let options = FileOptions::default()
             .compression_method(CompressionMethod::Deflated)
+            .clear_extra_data()
             .large_file(true);
 
         let mut zip = ZipWriter::new(file_writer);
@@ -1353,7 +1354,7 @@ pub fn csvwriter_thread<T: Serialize + Send + 'static>(
 pub fn write_signature(
     sig: &Signature,
     zip: &mut zip::ZipWriter<BufWriter<File>>,
-    zip_options: zip::write::FileOptions<()>,
+    zip_options: zip::write::FileOptions<ExtendedFileOptions>,
     sig_filename: &str,
 ) {
     let wrapped_sig = vec![sig];

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1277,12 +1277,11 @@ impl Hash for Params {
 }
 
 pub fn sigwriter(
-    // recv: std::sync::mpsc::Receiver<Vec<Signature>>,
     recv: std::sync::mpsc::Receiver<Option<Vec<Signature>>>,
     output: String,
 ) -> std::thread::JoinHandle<Result<()>> {
     std::thread::spawn(move || -> Result<()> {
-        // Cast output as PathBuf
+        // cast output as PathBuf
         let outpath: PathBuf = output.into();
 
         let file_writer = open_output_file(&outpath);
@@ -1293,7 +1292,7 @@ pub fn sigwriter(
 
         let mut zip = ZipWriter::new(file_writer);
         let mut manifest_rows: Vec<Record> = Vec::new();
-        // Keep track of MD5 sum occurrences to prevent overwriting duplicates
+        // keep track of MD5 sum occurrences to prevent overwriting duplicates
         let mut md5sum_occurrences: HashMap<String, usize> = HashMap::new();
 
         // Process all incoming signatures

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1290,8 +1290,8 @@ pub fn sigwriter(
         let file_writer = open_output_file(&outpath);
 
         let options = FileOptions::default()
-            .compression_method(CompressionMethod::Deflated)
-            .clear_extra_data()
+            .compression_method(CompressionMethod::Stored)
+            .unix_permissions(0o644)
             .large_file(true);
 
         let mut zip = ZipWriter::new(file_writer);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1290,7 +1290,7 @@ pub fn sigwriter(
         let file_writer = open_output_file(&outpath);
 
         let options = FileOptions::default()
-            .compression_method(CompressionMethod::Stored)
+            .compression_method(CompressionMethod::Deflated)
             .large_file(true);
 
         let mut zip = ZipWriter::new(file_writer);


### PR DESCRIPTION
Required changes for zip crate:
- update zip from 0.6 to 2.0 (NOT 2.3.1, as 2.1+ have a bug for large files)
- change `FileOptions` to reflect altered structure in 2.x

Simplifications:
- simplify zip writing to remove Arc and ZipMessage
> previously, we needed to keep track of additional information for all signatures in order to be able to write the manifest. Upon switching to sourmash core's manifest writing (#217), we no longer need to keep track of all signature information and remove this overly complicated implementation. 
