### PR TITLE
MRG: add additional weighted information to `manysearch` output

### DIFF
--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -81,45 +81,45 @@ pub fn manysearch(
                             // only calculate results if we have shared hashes
                             if overlap > 0.0 {
                                 let query_size = query.minhash.size() as f64;
-                                let target_size = against_mh.size() as f64;
                                 let containment_query_in_target = overlap / query_size;
-                                let containment_target_in_query = overlap / target_size;
-
-                                let max_containment =
-                                    containment_query_in_target.max(containment_target_in_query);
-                                let jaccard = overlap / (target_size + query_size - overlap);
-
-                                let qani = ani_from_containment(
-                                    containment_query_in_target,
-                                    against_mh.ksize() as f64,
-                                );
-                                let mani = ani_from_containment(
-                                    containment_target_in_query,
-                                    against_mh.ksize() as f64,
-                                );
-                                let query_containment_ani = Some(qani);
-                                let match_containment_ani = Some(mani);
-                                let average_containment_ani = Some((qani + mani) / 2.);
-                                let max_containment_ani = Some(f64::max(qani, mani));
-
-                                let (average_abund, median_abund, std_abund) = if calc_abund_stats {
-                                    match against_mh_ds.inflated_abundances(&query.minhash) {
-                                        Ok((abunds, sum_weighted_overlap)) => {
-                                            let average_abund = sum_weighted_overlap as f64 / abunds.len() as f64;
-                                            let median_abund = median(abunds.iter().cloned()).unwrap();
-                                            let std_abund = stddev(abunds.iter().cloned());
-                                            (average_abund, median_abund, std_abund)
-                                        }
-                                        Err(e) => {
-                                            eprintln!("Error calculating abundances for query: {}, against: {}; Error: {}", query.name, against_sig.name(), e);
-                                            continue;
-                                        }
-                                    }
-                                } else {
-                                    (1.0, 1.0, 0.0)
-                                };
-
                                 if containment_query_in_target > threshold {
+                                    let target_size = against_mh.size() as f64;
+                                    let containment_target_in_query = overlap / target_size;
+
+                                    let max_containment =
+                                        containment_query_in_target.max(containment_target_in_query);
+                                    let jaccard = overlap / (target_size + query_size - overlap);
+
+                                    let qani = ani_from_containment(
+                                        containment_query_in_target,
+                                        against_mh.ksize() as f64,
+                                    );
+                                    let mani = ani_from_containment(
+                                        containment_target_in_query,
+                                        against_mh.ksize() as f64,
+                                    );
+                                    let query_containment_ani = Some(qani);
+                                    let match_containment_ani = Some(mani);
+                                    let average_containment_ani = Some((qani + mani) / 2.);
+                                    let max_containment_ani = Some(f64::max(qani, mani));
+
+                                    let (average_abund, median_abund, std_abund) = if calc_abund_stats {
+                                        match against_mh_ds.inflated_abundances(&query.minhash) {
+                                            Ok((abunds, sum_weighted_overlap)) => {
+                                                let average_abund = sum_weighted_overlap as f64 / abunds.len() as f64;
+                                                let median_abund = median(abunds.iter().cloned()).unwrap();
+                                                let std_abund = stddev(abunds.iter().cloned());
+                                                (average_abund, median_abund, std_abund)
+                                            }
+                                            Err(e) => {
+                                                eprintln!("Error calculating abundances for query: {}, against: {}; Error: {}", query.name, against_sig.name(), e);
+                                                continue;
+                                            }
+                                        }
+                                    } else {
+                                        (1.0, 1.0, 0.0)
+                                    };
+
                                     results.push(SearchResult {
                                         query_name: query.name.clone(),
                                         query_md5: query.md5sum.clone(),

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -104,7 +104,7 @@ pub fn manysearch(
                                     let max_containment_ani = Some(f64::max(qani, mani));
 
                                     let (total_weighted_hashes, n_weighted_found, average_abund, median_abund, std_abund) = if calc_abund_stats {
-                                        match against_mh_ds.inflated_abundances(&query.minhash) {
+                                        match query.minhash.inflated_abundances(&against_mh_ds) {
                                             Ok((abunds, sum_weighted_overlap)) => {
                                                 let sum_all_abunds = against_mh_ds.sum_abunds() as usize;
                                                 let average_abund = sum_weighted_overlap as f64 / abunds.len() as f64;

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -103,13 +103,13 @@ pub fn manysearch(
                                     let average_containment_ani = Some((qani + mani) / 2.);
                                     let max_containment_ani = Some(f64::max(qani, mani));
 
-                                    let (average_abund, median_abund, std_abund) = if calc_abund_stats {
+                                    let (n_weighted_found, average_abund, median_abund, std_abund) = if calc_abund_stats {
                                         match against_mh_ds.inflated_abundances(&query.minhash) {
                                             Ok((abunds, sum_weighted_overlap)) => {
                                                 let average_abund = sum_weighted_overlap as f64 / abunds.len() as f64;
                                                 let median_abund = median(abunds.iter().cloned()).unwrap();
                                                 let std_abund = stddev(abunds.iter().cloned());
-                                                (average_abund, median_abund, std_abund)
+                                                (sum_weighted_overlap as usize, average_abund, median_abund, std_abund)
                                             }
                                             Err(e) => {
                                                 eprintln!("Error calculating abundances for query: {}, against: {}; Error: {}", query.name, against_sig.name(), e);
@@ -117,7 +117,7 @@ pub fn manysearch(
                                             }
                                         }
                                     } else {
-                                        (1.0, 1.0, 0.0)
+                                        (overlap as usize, 1.0, 1.0, 0.0)
                                     };
 
                                     results.push(SearchResult {
@@ -136,6 +136,7 @@ pub fn manysearch(
                                         match_containment_ani,
                                         average_containment_ani,
                                         max_containment_ani,
+                                        n_weighted_found,
                                     });
                                 }
                             }

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -110,7 +110,7 @@ pub fn manysearch(
                                                 let average_abund = sum_weighted_overlap as f64 / abunds.len() as f64;
                                                 let median_abund = median(abunds.iter().cloned()).unwrap();
                                                 let std_abund = stddev(abunds.iter().cloned());
-                                                (Some(sum_all_abunds), sum_weighted_overlap as usize, average_abund, median_abund, std_abund)
+                                                (Some(sum_all_abunds), Some(sum_weighted_overlap as usize), average_abund, median_abund, std_abund)
                                             }
                                             Err(e) => {
                                                 eprintln!("Error calculating abundances for query: {}, against: {}; Error: {}", query.name, against_sig.name(), e);
@@ -118,7 +118,7 @@ pub fn manysearch(
                                             }
                                         }
                                     } else {
-                                        (None, overlap as usize, 1.0, 1.0, 0.0)
+                                        (None, None, 1.0, 1.0, 0.0)
                                     };
 
                                     results.push(SearchResult {

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -72,7 +72,7 @@ pub fn manysearch(
                     if let Some(against_mh) = against_sig.minhash() {
                         for query in query_sketchlist.iter() {
                             // to do - let user choose?
-                            let calc_abund_stats = query.minhash.track_abundance();
+                            let calc_abund_stats = against_mh.track_abundance();
 
                             let against_mh_ds = against_mh.downsample_scaled(query.minhash.scaled()).unwrap();
                             let overlap =

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -103,13 +103,14 @@ pub fn manysearch(
                                     let average_containment_ani = Some((qani + mani) / 2.);
                                     let max_containment_ani = Some(f64::max(qani, mani));
 
-                                    let (n_weighted_found, average_abund, median_abund, std_abund) = if calc_abund_stats {
+                                    let (total_weighted_hashes, n_weighted_found, average_abund, median_abund, std_abund) = if calc_abund_stats {
                                         match against_mh_ds.inflated_abundances(&query.minhash) {
                                             Ok((abunds, sum_weighted_overlap)) => {
+                                                let sum_all_abunds = against_mh_ds.sum_abunds() as usize;
                                                 let average_abund = sum_weighted_overlap as f64 / abunds.len() as f64;
                                                 let median_abund = median(abunds.iter().cloned()).unwrap();
                                                 let std_abund = stddev(abunds.iter().cloned());
-                                                (sum_weighted_overlap as usize, average_abund, median_abund, std_abund)
+                                                (Some(sum_all_abunds), sum_weighted_overlap as usize, average_abund, median_abund, std_abund)
                                             }
                                             Err(e) => {
                                                 eprintln!("Error calculating abundances for query: {}, against: {}; Error: {}", query.name, against_sig.name(), e);
@@ -117,7 +118,7 @@ pub fn manysearch(
                                             }
                                         }
                                     } else {
-                                        (overlap as usize, 1.0, 1.0, 0.0)
+                                        (None, overlap as usize, 1.0, 1.0, 0.0)
                                     };
 
                                     results.push(SearchResult {
@@ -137,6 +138,7 @@ pub fn manysearch(
                                         average_containment_ani,
                                         max_containment_ani,
                                         n_weighted_found,
+                                        total_weighted_hashes,
                                     });
                                 }
                             }

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -98,7 +98,7 @@ pub fn mastiff_manysearch(
                                     match_containment_ani: None,
                                     average_containment_ani: None,
                                     max_containment_ani: None,
-                                    n_weighted_found: overlap,
+                                    n_weighted_found: None,
                                     total_weighted_hashes: None,
                                 });
                             }

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -98,6 +98,7 @@ pub fn mastiff_manysearch(
                                     match_containment_ani: None,
                                     average_containment_ani: None,
                                     max_containment_ani: None,
+                                    n_weighted_found: overlap,
                                 });
                             }
                         }

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -99,6 +99,7 @@ pub fn mastiff_manysearch(
                                     average_containment_ani: None,
                                     max_containment_ani: None,
                                     n_weighted_found: overlap,
+                                    total_weighted_hashes: None,
                                 });
                             }
                         }

--- a/src/python/tests/test_search.py
+++ b/src/python/tests/test_search.py
@@ -140,70 +140,72 @@ def test_simple(runtmp, zip_query, zip_against):
 
 def test_simple_abund(runtmp):
     # test with abund sig
-    query = get_test_data('SRR606249.sig.gz')
-    against_list = runtmp.output('against.txt')
-
     sig2 = get_test_data('2.fa.sig.gz')
     sig47 = get_test_data('47.fa.sig.gz')
     sig63 = get_test_data('63.fa.sig.gz')
-    make_file_list(against_list, [sig2, sig47, sig63])
+    query_list = runtmp.output('query.txt')
+    make_file_list(query_list, [sig2, sig47, sig63])
+
+    against = get_test_data('SRR606249.sig.gz')
 
     output = runtmp.output('out.csv')
 
-    runtmp.sourmash('scripts', 'manysearch', query, against_list,
+    runtmp.sourmash('scripts', 'manysearch', query_list, against,
                         '-o', output, '--scaled', '100000', '-k', '31')
 
     assert os.path.exists(output)
 
     df = pandas.read_csv(output)
-    assert len(df) == 1
+    assert len(df) == 3
 
     dd = df.to_dict(orient='index')
+    dd = list(sorted(dd.values(), key=lambda x: x['query_name']))
     print(dd)
 
-    for idx, row in dd.items():
-        # confirm hand-checked numbers
-        q = row['query_name'].split()[0]
-        assert q == "SRR606249"
-        m = row['match_name'].split()[0]
-        assert "NC_011665.1" in m
-        cont = float(row['containment'])
-        jaccard = float(row['jaccard'])
-        maxcont = float(row['max_containment'])
-        intersect_hashes = int(row['intersect_hashes'])
-        query_ani = float(row['query_containment_ani'])
-        match_ani = float(row['match_containment_ani'])
-        average_ani = float(row['average_containment_ani'])
-        max_ani = float(row['max_containment_ani'])
-        average_abund = float(row['average_abund'])
-        median_abund = float(row['median_abund'])
-        std_abund = float(row['std_abund'])
+    row = dd[0]
+    query_name = row['query_name'].split()[0]
+    average_abund = round(float(row['average_abund']), 4)
+    median_abund = round(float(row['median_abund']), 4)
+    std_abund = round(float(row['std_abund']), 4)
+    n_weighted_found = int(row['n_weighted_found'])
+    total_weighted_hashes = int(row['total_weighted_hashes'])
 
-        jaccard = round(jaccard, 4)
-        cont = round(cont, 4)
-        maxcont = round(maxcont, 4)
-        query_ani = round(query_ani, 4)
-        match_ani = round(match_ani, 4)
-        average_ani = round(average_ani, 4)
-        max_ani = round(max_ani, 4)
-        avg_abund = round(average_abund, 4)
-        med_abund = round(median_abund, 4)
-        std_abund = round(std_abund, 4)
-        print(q, m, f"{jaccard}", f"{cont}", f"{maxcont}",
-                    f"{query_ani}", f"{match_ani}", f"{average_ani}", f"{max_ani}",
-                    f"{avg_abund}", f"{med_abund}", f"{std_abund}")
+    assert query_name == 'CP001071.1'
+    assert average_abund == round(21.045454545454500, 4)
+    assert median_abund == 21.5
+    assert std_abund == round(5.644605411181010, 4)
+    assert n_weighted_found == 463
+    assert total_weighted_hashes == 73489
 
-        assert jaccard == 0.0047
-        assert cont == 0.0105
-        assert maxcont == 0.0105
-        assert intersect_hashes == 44
-        assert query_ani == 0.8632
-        assert match_ani == 0.8571
-        assert average_ani == 0.8602
-        assert max_ani == 0.8632
-        assert avg_abund == 10.3864
-        assert med_abund == 10.5
-        assert std_abund == 6.9322
+    row = dd[1]
+    query_name = row['query_name'].split()[0]
+    average_abund = round(float(row['average_abund']), 4)
+    median_abund = round(float(row['median_abund']), 4)
+    std_abund = round(float(row['std_abund']), 4)
+    n_weighted_found = int(row['n_weighted_found'])
+    total_weighted_hashes = int(row['total_weighted_hashes'])
+
+    assert query_name == 'NC_009661.1'
+    assert average_abund == round(11.365853658536600, 4)
+    assert median_abund == 11.0
+    assert std_abund == round(4.976805212676670, 4)
+    assert n_weighted_found == 466
+    assert total_weighted_hashes == 73489
+
+    row = dd[2]
+    query_name = row['query_name'].split()[0]
+    average_abund = round(float(row['average_abund']), 4)
+    median_abund = round(float(row['median_abund']), 4)
+    std_abund = round(float(row['std_abund']), 4)
+    n_weighted_found = int(row['n_weighted_found'])
+    total_weighted_hashes = int(row['total_weighted_hashes'])
+
+    assert query_name == 'NC_011665.1'
+    assert average_abund == round(10.386363636363600, 4)
+    assert median_abund == 10.5
+    assert std_abund == round(6.932190750047300, 4)
+    assert n_weighted_found == 457
+    assert total_weighted_hashes == 73489
 
 
 @pytest.mark.parametrize("zip_query", [False, True])

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1140,6 +1140,7 @@ pub struct SearchResult {
     pub average_containment_ani: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_containment_ani: Option<f64>,
+    pub n_weighted_found: usize,
 }
 
 pub struct InterimGatherResult {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1140,7 +1140,8 @@ pub struct SearchResult {
     pub average_containment_ani: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_containment_ani: Option<f64>,
-    pub n_weighted_found: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n_weighted_found: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_weighted_hashes: Option<usize>,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1141,6 +1141,8 @@ pub struct SearchResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_containment_ani: Option<f64>,
     pub n_weighted_found: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_weighted_hashes: Option<usize>,
 }
 
 pub struct InterimGatherResult {


### PR DESCRIPTION
Addresses https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/380

Note: in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/302, the meaning of 'query' and 'against' was flipped. For `manysearch`, unlike in `gather`/`prefetch`, 'query' is meant to be the genome and `against` is meant to be the metagenome. This PR switches them back, so that the `mgmanysearch` command line from [the containment search plugin](https://github.com/sourmash-bio/sourmash_plugin_containment_search/) matches the `manysearch` command line:

```
sourmash scripts mgmanysearch --queries f_prausnitzii.sig.zip b_uniformis.sig.zip --against CD*.sig.zip -o search.csv
```

vs

```
sourmash scripts manysearch query.txt against.txt -o search2.csv -t 0
```
where `query.txt` contains `f_prausnitzii.sig.zip\nb_uniformis.sig.zip` (the genomes) and `against.txt` contains the `CD*.sig.zip` files (the metagenomes).

Using the display code in https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/380 to display `search2.csv`, we then get:
```
query             p_genome avg_abund   p_metag   metagenome name
--------          -------- ---------   -------   ---------------
B. uniformis        48.3%     2.0       3.4%     CD136
B. uniformis        62.6%    14.5      26.5%     CD237
F. prausnitzii       4.3%    24.7       2.5%     CD136
```
which matches the mgmanysearch output:
```
query             p_genome avg_abund   p_metag   metagenome name
--------          -------- ---------   -------   ---------------
F. prausnitzii       4.3%    24.7       2.5%     CD136
B. uniformis        48.3%     2.0       3.4%     CD136
F. prausnitzii       0.0%     0.0       0.0%     CD237
B. uniformis        62.6%    14.5      26.5%     CD237
```
