### PR TITLE
MRG: fix deprecated method warning in `lib.rs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ fn do_cluster(
 }
 
 #[pymodule]
-fn sourmash_plugin_branchwater(_py: Python, m: &PyModule) -> PyResult<()> {
+fn sourmash_plugin_branchwater(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_manysearch, m)?)?;
     m.add_function(wrap_pyfunction!(do_fastgather, m)?)?;
     m.add_function(wrap_pyfunction!(do_fastmultigather, m)?)?;


### PR DESCRIPTION
Fix this warning:
```
warning: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
   --> src/lib.rs:310:45
    |
310 | fn sourmash_plugin_branchwater(_py: Python, m: &PyModule) -> PyResult<(...
    |                                             ^
    |
    = note: `#[warn(deprecated)]` on by default
```
by swiping code from directsketch.

Note, it looks to me like this will make the pyo3 version bump in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/382 work as well 🎉 