### PR TITLE
MRG: misc cleanup

### DIFF
--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -69,7 +69,6 @@ class Branchwater_Manysearch(CommandLinePlugin):
     def main(self, args):
         print_version()
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / moltype: {args.moltype} / threshold: {args.threshold}")
-        args.moltype = args.moltype.lower()
         num_threads = set_thread_pool(args.cores)
 
         notify(f"searching all sketches in '{args.query_paths}' against '{args.against_paths}' using {num_threads} threads")
@@ -117,7 +116,6 @@ class Branchwater_Fastgather(CommandLinePlugin):
     def main(self, args):
         print_version()
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / moltype: {args.moltype} / threshold bp: {args.threshold_bp}")
-        args.moltype = args.moltype.lower()
 
         num_threads = set_thread_pool(args.cores)
 
@@ -164,7 +162,6 @@ class Branchwater_Fastmultigather(CommandLinePlugin):
     def main(self, args):
         print_version()
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / moltype: {args.moltype} / threshold bp: {args.threshold_bp}")
-        args.moltype = args.moltype.lower()
 
         num_threads = set_thread_pool(args.cores)
 
@@ -209,7 +206,6 @@ class Branchwater_Index(CommandLinePlugin):
 
     def main(self, args):
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / moltype: {args.moltype} ")
-        args.moltype = args.moltype.lower()
 
         num_threads = set_thread_pool(args.cores)
 
@@ -274,7 +270,6 @@ class Branchwater_Multisearch(CommandLinePlugin):
     def main(self, args):
         print_version()
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / moltype: {args.moltype} / threshold: {args.threshold}")
-        args.moltype = args.moltype.lower()
 
         num_threads = set_thread_pool(args.cores)
 
@@ -321,7 +316,6 @@ class Branchwater_Pairwise(CommandLinePlugin):
     def main(self, args):
         print_version()
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / moltype: {args.moltype} / threshold: {args.threshold}")
-        args.moltype = args.moltype.lower()
 
         num_threads = set_thread_pool(args.cores)
 

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -17,6 +17,10 @@ def zip_query(request):
     return request.param
 
 @pytest.fixture(params=[True, False])
+def zip_db(request):
+    return request.param
+
+@pytest.fixture(params=[True, False])
 def zip_against(request):
     return request.param
 

--- a/src/python/tests/sourmash_tst_utils.py
+++ b/src/python/tests/sourmash_tst_utils.py
@@ -14,6 +14,23 @@ from io import open  # pylint: disable=redefined-builtin
 from io import StringIO
 
 
+def get_test_data(filename):
+    thisdir = os.path.dirname(__file__)
+    return os.path.join(thisdir, 'test-data', filename)
+
+
+def make_file_list(filename, paths):
+    with open(filename, 'wt') as fp:
+        fp.write("\n".join(paths))
+        fp.write("\n")
+
+
+def zip_siglist(runtmp, siglist, db):
+    runtmp.sourmash('sig', 'cat', siglist,
+                    '-o', db)
+    return db
+
+
 def scriptpath(scriptname='sourmash'):
     """Return the path to the scripts, in both dev and install situations."""
     # note - it doesn't matter what the scriptname is here, as long as

--- a/src/python/tests/test_cluster.py
+++ b/src/python/tests/test_cluster.py
@@ -2,15 +2,7 @@ import os, csv
 import pytest
 
 from . import sourmash_tst_utils as utils
-
-def get_test_data(filename):
-    thisdir = os.path.dirname(__file__)
-    return os.path.join(thisdir, 'test-data', filename)
-
-def make_file_list(filename, paths):
-    with open(filename, 'wt') as fp:
-        fp.write("\n".join(paths))
-        fp.write("\n")
+from .sourmash_tst_utils import get_test_data, make_file_list
 
 
 def test_installed(runtmp):

--- a/src/python/tests/test_fastgather.py
+++ b/src/python/tests/test_fastgather.py
@@ -4,23 +4,7 @@ import pandas
 
 import sourmash
 from . import sourmash_tst_utils as utils
-
-
-def get_test_data(filename):
-    thisdir = os.path.dirname(__file__)
-    return os.path.join(thisdir, 'test-data', filename)
-
-
-def make_file_list(filename, paths):
-    with open(filename, 'wt') as fp:
-        fp.write("\n".join(paths))
-        fp.write("\n")
-
-
-def zip_siglist(runtmp, siglist, db):
-    runtmp.sourmash('sig', 'cat', siglist,
-                    '-o', db)
-    return db
+from .sourmash_tst_utils import (get_test_data, make_file_list, zip_siglist)
 
 
 def test_installed(runtmp):
@@ -30,7 +14,6 @@ def test_installed(runtmp):
     assert 'usage:  fastgather' in runtmp.last_result.err
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_simple(runtmp, zip_against):
     # test basic execution!
     query = get_test_data('SRR606249.sig.gz')
@@ -58,7 +41,6 @@ def test_simple(runtmp, zip_against):
     assert {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'gather_result_rank', 'intersect_bp'}.issubset(keys)
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_simple_with_prefetch(runtmp, zip_against):
     # test basic execution!
     query = get_test_data('SRR606249.sig.gz')
@@ -93,7 +75,6 @@ def test_simple_with_prefetch(runtmp, zip_against):
     assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp'}
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_missing_query(runtmp, capfd, zip_against):
     # test missing query
     query = runtmp.output('no-such-file')
@@ -122,7 +103,6 @@ def test_missing_query(runtmp, capfd, zip_against):
     assert 'Error: No such file or directory' in captured.err
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_bad_query(runtmp, capfd, zip_against):
     # test non-sig query
     query = runtmp.output('no-such-file')
@@ -154,7 +134,6 @@ def test_bad_query(runtmp, capfd, zip_against):
     assert 'Error: Fastgather requires a single query sketch. Check input:' in captured.err
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_missing_against(runtmp, capfd, zip_against):
     # test missing against
     query = get_test_data('SRR606249.sig.gz')
@@ -278,7 +257,6 @@ def test_bad_against_3(runtmp, capfd):
     assert 'InvalidArchive' in captured.err
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_against_multisigfile(runtmp, zip_against):
     # test against a sigfile that contains multiple sketches
     query = get_test_data('SRR606249.sig.gz')
@@ -311,7 +289,6 @@ def test_against_multisigfile(runtmp, zip_against):
     # @CTB this is a bug :(. It should load multiple sketches properly!
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_query_multisigfile(runtmp, capfd, zip_against):
     # test with a sigfile that contains multiple sketches
     against_list = runtmp.output('against.txt')
@@ -341,7 +318,6 @@ def test_query_multisigfile(runtmp, capfd, zip_against):
     assert "Error: Fastgather requires a single query sketch. Check input:" in captured.err
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_against_nomatch(runtmp, capfd, zip_against):
     # test with 'against' file containing a non-matching ksize
     query = get_test_data('SRR606249.sig.gz')
@@ -370,7 +346,6 @@ def test_against_nomatch(runtmp, capfd, zip_against):
     assert 'WARNING: skipped 1 search paths - no compatible signatures.' in captured.err
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_md5s(runtmp, zip_against):
     # check that the correct md5sums (of the original sketches) are in
     # the output files
@@ -424,7 +399,6 @@ def test_md5s(runtmp, zip_against):
             assert ss.md5sum() in md5s
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_csv_columns_vs_sourmash_prefetch(runtmp, zip_against):
     # the column names should be strict subsets of sourmash prefetch cols
     query = get_test_data('SRR606249.sig.gz')
@@ -466,7 +440,6 @@ def test_csv_columns_vs_sourmash_prefetch(runtmp, zip_against):
     assert diff_keys == set(['unique_intersect_bp', 'median_abund', 'f_match_orig', 'std_abund', 'average_abund', 'f_unique_to_query', 'remaining_bp', 'f_unique_weighted', 'sum_weighted_found', 'total_weighted_hashes', 'n_unique_weighted_found', 'f_orig_query', 'f_match'])
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_fastgather_gatherout_as_picklist(runtmp, zip_against):
     # should be able to use fastgather gather output as picklist
     query = get_test_data('SRR606249.sig.gz')
@@ -508,7 +481,6 @@ def test_fastgather_gatherout_as_picklist(runtmp, zip_against):
     assert picklist_df.equals(full_df)
 
 
-@pytest.mark.parametrize('zip_against', [False, True])
 def test_fastgather_prefetchout_as_picklist(runtmp, zip_against):
     # should be able to use fastgather prefetch output as picklist
     query = get_test_data('SRR606249.sig.gz')

--- a/src/python/tests/test_fastmultigather.py
+++ b/src/python/tests/test_fastmultigather.py
@@ -8,17 +8,7 @@ import shutil
 
 import sourmash
 from . import sourmash_tst_utils as utils
-
-
-def get_test_data(filename):
-    thisdir = os.path.dirname(__file__)
-    return os.path.join(thisdir, 'test-data', filename)
-
-
-def make_file_list(filename, paths):
-    with open(filename, 'wt') as fp:
-        fp.write("\n".join(paths))
-        fp.write("\n")
+from .sourmash_tst_utils import (get_test_data, make_file_list, zip_siglist)
 
 
 def index_siglist(runtmp, siglist, db, *, ksize=31, scaled=1000, moltype='DNA',
@@ -36,11 +26,6 @@ def test_installed(runtmp):
 
     assert 'usage:  fastmultigather' in runtmp.last_result.err
 
-
-def zip_siglist(runtmp, siglist, db):
-    runtmp.sourmash('sig', 'cat', siglist,
-                    '-o', db)
-    return db
 
 def test_simple(runtmp, zip_against):
     # test basic execution!

--- a/src/python/tests/test_index.py
+++ b/src/python/tests/test_index.py
@@ -5,17 +5,7 @@ import sourmash
 import shutil
 
 from . import sourmash_tst_utils as utils
-
-
-def get_test_data(filename):
-    thisdir = os.path.dirname(__file__)
-    return os.path.join(thisdir, 'test-data', filename)
-
-
-def make_file_list(filename, paths):
-    with open(filename, 'wt') as fp:
-        fp.write("\n".join(paths))
-        fp.write("\n")
+from .sourmash_tst_utils import (get_test_data, make_file_list, zip_siglist)
 
 
 def test_installed(runtmp):

--- a/src/python/tests/test_manysearch.py
+++ b/src/python/tests/test_manysearch.py
@@ -4,17 +4,7 @@ import pandas
 import sourmash
 
 from . import sourmash_tst_utils as utils
-
-
-def get_test_data(filename):
-    thisdir = os.path.dirname(__file__)
-    return os.path.join(thisdir, 'test-data', filename)
-
-
-def make_file_list(filename, paths):
-    with open(filename, 'wt') as fp:
-        fp.write("\n".join(paths))
-        fp.write("\n")
+from .sourmash_tst_utils import (get_test_data, make_file_list, zip_siglist)
 
 
 def test_installed(runtmp):
@@ -23,10 +13,6 @@ def test_installed(runtmp):
 
     assert 'usage:  manysearch' in runtmp.last_result.err
 
-def zip_siglist(runtmp, siglist, db):
-    runtmp.sourmash('sig', 'cat', siglist,
-                    '-o', db)
-    return db
 
 def index_siglist(runtmp, siglist, db, ksize=31, scaled=1000, moltype='DNA'):
     # build index
@@ -35,8 +21,6 @@ def index_siglist(runtmp, siglist, db, ksize=31, scaled=1000, moltype='DNA'):
                     '--moltype', moltype)
     return db
 
-@pytest.mark.parametrize("zip_query", [False, True])
-@pytest.mark.parametrize("zip_against", [False, True])
 def test_simple(runtmp, zip_query, zip_against):
     # test basic execution!
     query_list = runtmp.output('query.txt')
@@ -192,7 +176,6 @@ def test_simple_abund(runtmp):
     assert total_weighted_hashes == 73489
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_simple_indexed(runtmp, zip_query):
     # test basic execution!
     query_list = runtmp.output('query.txt')
@@ -249,8 +232,6 @@ def test_simple_indexed(runtmp, zip_query):
                 assert query_ani == 0.9772
 
 
-@pytest.mark.parametrize("indexed", [False, True])
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_simple_with_cores(runtmp, capfd, indexed, zip_query):
     # test basic execution with -c argument (that it runs, at least!)
     query_list = runtmp.output('query.txt')
@@ -283,8 +264,6 @@ def test_simple_with_cores(runtmp, capfd, indexed, zip_query):
     assert " using 4 threads" in result.err
 
 
-@pytest.mark.parametrize("indexed", [False, True])
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_simple_threshold(runtmp, indexed, zip_query):
     # test with a simple threshold => only 3 results
     query_list = runtmp.output('query.txt')
@@ -313,7 +292,6 @@ def test_simple_threshold(runtmp, indexed, zip_query):
     assert len(df) == 3
 
 
-@pytest.mark.parametrize("indexed", [False, True])
 def test_simple_manifest(runtmp, indexed):
     # test with a simple threshold => only 3 results
     query_list = runtmp.output('query.txt')
@@ -347,8 +325,6 @@ def test_simple_manifest(runtmp, indexed):
     assert len(df) == 3
 
 
-@pytest.mark.parametrize("indexed", [False, True])
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_missing_query(runtmp, capfd, indexed, zip_query):
     # test with a missing query list
     query_list = runtmp.output('query.txt')
@@ -379,7 +355,6 @@ def test_missing_query(runtmp, capfd, indexed, zip_query):
     assert 'Error: No such file or directory' in captured.err
 
 
-@pytest.mark.parametrize("indexed", [False, True])
 def test_sig_query(runtmp, capfd, indexed):
     # test with a single sig query (a .sig.gz file)
     against_list = runtmp.output('against.txt')
@@ -399,7 +374,6 @@ def test_sig_query(runtmp, capfd, indexed):
                         '-o', output)
 
 
-@pytest.mark.parametrize("indexed", [False, True])
 def test_bad_query_2(runtmp, capfd, indexed):
     # test with a bad query list (a missing file)
     query_list = runtmp.output('query.txt')
@@ -453,7 +427,6 @@ def test_bad_query_3(runtmp, capfd):
     assert 'InvalidArchive' in captured.err
 
 
-@pytest.mark.parametrize("indexed", [False, True])
 def test_missing_against(runtmp, capfd, indexed):
     # test with a missing against list
     query_list = runtmp.output('query.txt')
@@ -524,7 +497,6 @@ def test_bad_against(runtmp, capfd):
     assert "WARNING: 1 search paths failed to load. See error messages above." in captured.err
 
 
-@pytest.mark.parametrize("indexed", [False, True])
 def test_empty_query(runtmp, indexed, capfd):
     # test with an empty query list
     query_list = runtmp.output('query.txt')
@@ -552,8 +524,6 @@ def test_empty_query(runtmp, indexed, capfd):
     assert "No query signatures loaded, exiting." in captured.err
 
 
-@pytest.mark.parametrize("indexed", [False, True])
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_nomatch_query(runtmp, capfd, indexed, zip_query):
     # test a non-matching (diff ksize) in query; do we get warning message?
     query_list = runtmp.output('query.txt')
@@ -584,8 +554,6 @@ def test_nomatch_query(runtmp, capfd, indexed, zip_query):
     assert 'WARNING: skipped 1 query paths - no compatible signatures.' in captured.err
 
 
-@pytest.mark.parametrize("zip_against", [False, True])
-@pytest.mark.parametrize("indexed", [False, True])
 def test_load_only_one_bug(runtmp, capfd, indexed, zip_against):
     # check that we behave properly when presented with multiple against
     # sketches
@@ -619,8 +587,6 @@ def test_load_only_one_bug(runtmp, capfd, indexed, zip_against):
     assert not 'WARNING: no compatible sketches in path ' in captured.err
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
-@pytest.mark.parametrize("indexed", [False, True])
 def test_load_only_one_bug_as_query(runtmp, capfd, indexed, zip_query):
     # check that we behave properly when presented with multiple query
     # sketches in one file, with only one matching.
@@ -656,8 +622,6 @@ def test_load_only_one_bug_as_query(runtmp, capfd, indexed, zip_query):
     assert not 'WARNING: no compatible sketches in path ' in captured.err
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
-@pytest.mark.parametrize("indexed", [False, True])
 def test_md5(runtmp, indexed, zip_query):
     # test that md5s match what was in the original files, not downsampled etc.
     query_list = runtmp.output('query.txt')

--- a/src/python/tests/test_multisearch.py
+++ b/src/python/tests/test_multisearch.py
@@ -5,17 +5,7 @@ import pandas
 import sourmash
 
 from . import sourmash_tst_utils as utils
-
-
-def get_test_data(filename):
-    thisdir = os.path.dirname(__file__)
-    return os.path.join(thisdir, 'test-data', filename)
-
-
-def make_file_list(filename, paths):
-    with open(filename, 'wt') as fp:
-        fp.write("\n".join(paths))
-        fp.write("\n")
+from .sourmash_tst_utils import (get_test_data, make_file_list, zip_siglist)
 
 
 def test_installed(runtmp):
@@ -24,13 +14,7 @@ def test_installed(runtmp):
 
     assert 'usage:  multisearch' in runtmp.last_result.err
 
-def zip_siglist(runtmp, siglist, db):
-    runtmp.sourmash('sig', 'cat', siglist,
-                    '-o', db)
-    return db
 
-@pytest.mark.parametrize("zip_query", [False, True])
-@pytest.mark.parametrize("zip_db", [False, True])
 def test_simple_no_ani(runtmp, zip_query, zip_db):
     # test basic execution!
     query_list = runtmp.output('query.txt')
@@ -99,8 +83,6 @@ def test_simple_no_ani(runtmp, zip_query, zip_db):
                 assert intersect_hashes == 2529
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
-@pytest.mark.parametrize("zip_db", [False, True])
 def test_simple_ani(runtmp, zip_query, zip_db):
     # test basic execution!
     query_list = runtmp.output('query.txt')
@@ -186,8 +168,6 @@ def test_simple_ani(runtmp, zip_query, zip_db):
                 assert max_ani == 0.9772
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
-@pytest.mark.parametrize("zip_db", [False, True])
 def test_simple_threshold(runtmp, zip_query, zip_db):
     # test with a simple threshold => only 3 results
     query_list = runtmp.output('query.txt')
@@ -243,7 +223,6 @@ def test_simple_manifest(runtmp):
     assert len(df) == 3
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_missing_query(runtmp, capfd, zip_query):
     # test with a missing query list
     query_list = runtmp.output('query.txt')
@@ -344,7 +323,6 @@ def test_bad_query_3(runtmp, capfd):
     assert 'InvalidArchive' in captured.err
 
 
-@pytest.mark.parametrize("zip_db", [False, True])
 def test_missing_against(runtmp, capfd, zip_db):
     # test with a missing against list
     query_list = runtmp.output('query.txt')
@@ -445,7 +423,6 @@ def test_empty_query(runtmp, capfd):
     # @CTB
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_nomatch_query(runtmp, capfd, zip_query):
     # test a non-matching (diff ksize) in query; do we get warning message?
     query_list = runtmp.output('query.txt')
@@ -474,7 +451,6 @@ def test_nomatch_query(runtmp, capfd, zip_query):
     assert 'WARNING: skipped 1 query paths - no compatible signatures' in captured.err
 
 
-@pytest.mark.parametrize("zip_db", [False, True])
 def test_load_only_one_bug(runtmp, capfd, zip_db):
     # check that we behave properly when presented with multiple against
     # sketches
@@ -506,7 +482,6 @@ def test_load_only_one_bug(runtmp, capfd, zip_db):
     assert not 'WARNING: no compatible sketches in path' in captured.err
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_load_only_one_bug_as_query(runtmp, capfd, zip_query):
     # check that we behave properly when presented with multiple query
     # sketches in one file, with only one matching.
@@ -538,8 +513,6 @@ def test_load_only_one_bug_as_query(runtmp, capfd, zip_query):
     assert not 'WARNING: no compatible sketches in path ' in captured.err
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
-@pytest.mark.parametrize("zip_db", [False, True])
 def test_md5(runtmp, zip_query, zip_db):
     # test that md5s match what was in the original files, not downsampled etc.
     query_list = runtmp.output('query.txt')

--- a/src/python/tests/test_pairwise.py
+++ b/src/python/tests/test_pairwise.py
@@ -5,17 +5,7 @@ import pandas
 import sourmash
 
 from . import sourmash_tst_utils as utils
-
-
-def get_test_data(filename):
-    thisdir = os.path.dirname(__file__)
-    return os.path.join(thisdir, 'test-data', filename)
-
-
-def make_file_list(filename, paths):
-    with open(filename, 'wt') as fp:
-        fp.write("\n".join(paths))
-        fp.write("\n")
+from .sourmash_tst_utils import (get_test_data, make_file_list, zip_siglist)
 
 
 def test_installed(runtmp):
@@ -24,13 +14,7 @@ def test_installed(runtmp):
 
     assert 'usage:  pairwise' in runtmp.last_result.err
 
-def zip_siglist(runtmp, siglist, db):
-    runtmp.sourmash('sig', 'cat', siglist,
-                    '-o', db)
-    return db
 
-
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_simple_no_ani(runtmp, zip_query):
     # test basic execution!
     query_list = runtmp.output('query.txt')
@@ -81,7 +65,6 @@ def test_simple_no_ani(runtmp, zip_query):
             assert intersect_hashes == 2529
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_simple_ani(runtmp, zip_query):
     # test basic execution!
     query_list = runtmp.output('query.txt')
@@ -140,7 +123,6 @@ def test_simple_ani(runtmp, zip_query):
             assert max_ani == 0.9772
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_simple_threshold(runtmp, zip_query):
     # test with a simple threshold => only 3 results
     query_list = runtmp.output('query.txt')
@@ -248,7 +230,6 @@ def test_bad_query_2(runtmp, capfd):
     assert 'InvalidArchive' in captured.err
 
 
-@pytest.mark.parametrize("zip_db", [False, True])
 def test_missing_query(runtmp, capfd, zip_db):
     # test with a missing query list
     query_list = runtmp.output('query.txt')
@@ -290,7 +271,6 @@ def test_empty_query(runtmp):
     # @CTB
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_nomatch_query(runtmp, capfd, zip_query):
     # test a non-matching (diff ksize) in query; do we get warning message?
     query_list = runtmp.output('query.txt')
@@ -317,7 +297,6 @@ def test_nomatch_query(runtmp, capfd, zip_query):
     assert 'WARNING: skipped 1 analysis paths - no compatible signatures' in captured.err
 
 
-@pytest.mark.parametrize("zip_db", [False, True])
 def test_load_only_one_bug(runtmp, capfd, zip_db):
     # check that we behave properly when presented with multiple query
     # sketches
@@ -347,7 +326,6 @@ def test_load_only_one_bug(runtmp, capfd, zip_db):
     assert not 'WARNING: no compatible sketches in path ' in captured.err
 
 
-@pytest.mark.parametrize("zip_query", [False, True])
 def test_md5(runtmp, zip_query):
     # test that md5s match what was in the original files, not downsampled etc.
     query_list = runtmp.output('query.txt')

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1091,7 +1091,7 @@ pub fn consume_query_by_gather(
 
 pub fn build_selection(ksize: u8, scaled: usize, moltype: &str) -> Selection {
     let hash_function = match moltype {
-        "dna" => HashFunctions::Murmur64Dna,
+        "DNA" => HashFunctions::Murmur64Dna,
         "protein" => HashFunctions::Murmur64Protein,
         "dayhoff" => HashFunctions::Murmur64Dayhoff,
         "hp" => HashFunctions::Murmur64Hp,


### PR DESCRIPTION
Cleanup:
- make moltype "DNA" instead of "dna" to match sourmash

Refactoring:
- consolidate duplicate test functions
- move common parametrize marks from pytest into `conftest.py`
- rename `test_gather.py` to `test_fastgather.py`
- rename `test_multigather.py` to `test_fastmultigather.py`