### PR TITLE
MRG: optionally, create empty results files for in-memory `fastmultigather`

### DIFF
--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -163,11 +163,13 @@ pub fn fastmultigather(
                             // touch output files
                             match std::fs::File::create(&prefetch_output) {
                                 Ok(_) => {}
-                                Err(e) => eprintln!("Failed to create prefetch output: {}", e),
+                                Err(e) => {
+                                    eprintln!("Failed to create empty prefetch output: {}", e)
+                                }
                             }
                             match std::fs::File::create(&gather_output) {
                                 Ok(_) => {}
-                                Err(e) => eprintln!("Failed to create gather output: {}", e),
+                                Err(e) => eprintln!("Failed to create empty gather output: {}", e),
                             }
                         }
                     }

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -32,6 +32,7 @@ pub fn fastmultigather(
     selection: &Selection,
     allow_failed_sigpaths: bool,
     save_matches: bool,
+    create_empty_results: bool,
 ) -> Result<()> {
     // load query collection
     let query_collection = load_collection(
@@ -156,6 +157,13 @@ pub fn fastmultigather(
                         }
                     } else {
                         println!("No matches to '{}'", location);
+                        if create_empty_results {
+                            let prefetch_output = format!("{}.prefetch.csv", location);
+                            let gather_output = format!("{}.gather.csv", location);
+                            // touch output files
+                            std::fs::File::create(&prefetch_output)?;
+                            std::fs::File::create(&gather_output)?;
+                        }
                     }
                 } else {
                     // different warning here? Could not load sig from record??

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -161,8 +161,14 @@ pub fn fastmultigather(
                             let prefetch_output = format!("{}.prefetch.csv", location);
                             let gather_output = format!("{}.gather.csv", location);
                             // touch output files
-                            std::fs::File::create(&prefetch_output)?;
-                            std::fs::File::create(&gather_output)?;
+                            match std::fs::File::create(&prefetch_output) {
+                                Ok(_) => {}
+                                Err(e) => eprintln!("Failed to create prefetch output: {}", e),
+                            }
+                            match std::fs::File::create(&gather_output) {
+                                Ok(_) => {}
+                                Err(e) => eprintln!("Failed to create gather output: {}", e),
+                            }
                         }
                     }
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ fn do_fastgather(
 }
 
 #[pyfunction]
-#[pyo3(signature = (query_filenames, siglist_path, threshold_bp, ksize, scaled, moltype, output_path=None, save_matches=false))]
+#[pyo3(signature = (query_filenames, siglist_path, threshold_bp, ksize, scaled, moltype, output_path=None, save_matches=false, create_empty_results=false))]
 fn do_fastmultigather(
     query_filenames: String,
     siglist_path: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ fn do_fastmultigather(
     moltype: String,
     output_path: Option<String>,
     save_matches: bool,
+    create_empty_results: bool,
 ) -> anyhow::Result<u8> {
     let againstfile_path: camino::Utf8PathBuf = siglist_path.clone().into();
     let selection = build_selection(ksize, scaled, &moltype);
@@ -149,6 +150,7 @@ fn do_fastmultigather(
             &selection,
             allow_failed_sigpaths,
             save_matches,
+            create_empty_results,
         ) {
             Ok(_) => Ok(0),
             Err(e) => {

--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -156,8 +156,11 @@ class Branchwater_Fastmultigather(CommandLinePlugin):
                        help = 'molecule type (DNA, protein, dayhoff, or hp; default DNA)')
         p.add_argument('-c', '--cores', default=0, type=int,
                 help='number of cores to use (default is all available)')
-        p.add_argument('-o', '--output', help='CSV output file for matches')
-        p.add_argument('--save-matches', action='store_true', default=False, help='save matched hashes for every input to a signature')
+        p.add_argument('-o', '--output', help='CSV output file for matches. Used for non-rocksdb searches only.')
+        p.add_argument('--create-empty-results', action = 'store_true',
+                       default=False, help='create empty results file(s) even if no matches')
+        p.add_argument('--save-matches', action='store_true',
+                       default=False, help='save matched hashes for every input to a signature')
 
 
     def main(self, args):
@@ -175,7 +178,8 @@ class Branchwater_Fastmultigather(CommandLinePlugin):
                                                                 args.scaled,
                                                                 args.moltype,
                                                                 args.output,
-                                                                args.save_matches
+                                                                args.save_matches,
+                                                                args.create_empty_results
                                                                 )
         if status == 0:
             notify(f"...fastmultigather is done!")

--- a/src/python/tests/test_fastmultigather.py
+++ b/src/python/tests/test_fastmultigather.py
@@ -43,13 +43,9 @@ def test_simple(runtmp, zip_against):
     if zip_against:
         against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
-    cwd = os.getcwd()
-    try:
-        os.chdir(runtmp.output(''))
-        runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
-                        '-s', '100000', '-t', '0')
-    finally:
-        os.chdir(cwd)
+
+    runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
+                        '-s', '100000', '-t', '0', in_directory=runtmp.output(''))
 
     print(os.listdir(runtmp.output('')))
 
@@ -87,13 +83,8 @@ def test_simple_space_in_signame(runtmp):
 
     make_file_list(against_list, [sig2, sig47, sig63])
 
-    cwd = os.getcwd()
-    try:
-        os.chdir(runtmp.output(''))
-        runtmp.sourmash('scripts', 'fastmultigather', renamed_query, against_list,
-                        '-s', '100000', '-t', '0')
-    finally:
-        os.chdir(cwd)
+    runtmp.sourmash('scripts', 'fastmultigather', renamed_query, against_list,
+                    '-s', '100000', '-t', '0', in_directory=runtmp.output(''))
 
     print(os.listdir(runtmp.output('')))
 
@@ -118,13 +109,8 @@ def test_simple_zip_query(runtmp):
 
     query_list = zip_siglist(runtmp, query_list, runtmp.output('query.zip'))
 
-    cwd = os.getcwd()
-    try:
-        os.chdir(runtmp.output(''))
-        runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
-                        '-s', '100000', '-t', '0')
-    finally:
-        os.chdir(cwd)
+    runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
+                    '-s', '100000', '-t', '0', in_directory=runtmp.output('') )
 
     print(os.listdir(runtmp.output('')))
 
@@ -161,13 +147,8 @@ def test_simple_read_manifests(runtmp):
     runtmp.sourmash("sig", "manifest", query, "-o", query_mf)
     runtmp.sourmash("sig", "manifest", against_list, "-o", against_mf)
 
-    cwd = os.getcwd()
-    try:
-        os.chdir(runtmp.output(''))
-        runtmp.sourmash('scripts', 'fastmultigather', query_mf, against_list,
-                        '-s', '100000', '-t', '0')
-    finally:
-        os.chdir(cwd)
+    runtmp.sourmash('scripts', 'fastmultigather', query_mf, against_list,
+                    '-s', '100000', '-t', '0', in_directory=runtmp.output(''))
 
     print(os.listdir(runtmp.output('')))
 
@@ -570,13 +551,8 @@ def test_md5(runtmp, zip_query):
     if zip_query:
         query_list = zip_siglist(runtmp, query_list, runtmp.output('query.zip'))
 
-    cwd = os.getcwd()
-    try:
-        os.chdir(runtmp.output(''))
-        runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
-                        '-s', '100000', '-t', '0')
-    finally:
-        os.chdir(cwd)
+    runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
+                    '-s', '100000', '-t', '0', in_directory=runtmp.output(''))
 
     print(os.listdir(runtmp.output('')))
 
@@ -668,13 +644,8 @@ def test_csv_columns_vs_sourmash_prefetch(runtmp, zip_query, zip_against):
     if zip_against:
         against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
-    cwd = os.getcwd()
-    try:
-        os.chdir(runtmp.output(''))
-        runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
-                        '-s', '100000', '-t', '0')
-    finally:
-        os.chdir(cwd)
+    runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
+                    '-s', '100000', '-t', '0', in_directory=runtmp.output(''))
 
     g_output = runtmp.output('SRR606249.gather.csv')
     p_output = runtmp.output('SRR606249.prefetch.csv')
@@ -1268,13 +1239,8 @@ def test_create_empty_results(runtmp):
     make_file_list(query_list, [sig2])
     make_file_list(against_list, [sig47, sig63])
 
-    cwd = os.getcwd()
-    try:
-        os.chdir(runtmp.output(''))
-        runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
-                        '-s', '100000', '-t', '0', '--create-empty-results')
-    finally:
-        os.chdir(cwd)
+    runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
+                    '-s', '100000', '-t', '0', '--create-empty-results', in_directory=runtmp.output(''))
 
     print(os.listdir(runtmp.output('')))
 

--- a/src/python/tests/test_fastmultigather.py
+++ b/src/python/tests/test_fastmultigather.py
@@ -1254,3 +1254,30 @@ def test_save_matches(runtmp):
     mg_ss = list(sourmash.load_file_as_signatures(query, ksize=31))[0]
     assert match_mh.contained_by(mg_ss.minhash) == 1.0
     assert mg_ss.minhash.contained_by(match_mh) < 1
+
+
+def test_create_empty_results(runtmp):
+    # sig2 has 0 hashes in common with 47 and 63
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+
+    query_list = runtmp.output('query.txt')
+    against_list = runtmp.output('against.txt')
+
+    make_file_list(query_list, [sig2])
+    make_file_list(against_list, [sig47, sig63])
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(runtmp.output(''))
+        runtmp.sourmash('scripts', 'fastmultigather', query_list, against_list,
+                        '-s', '100000', '-t', '0', '--create-empty-results')
+    finally:
+        os.chdir(cwd)
+
+    print(os.listdir(runtmp.output('')))
+
+    g_output = runtmp.output('CP001071.1.gather.csv')
+    p_output = runtmp.output('CP001071.1.prefetch.csv')
+    assert os.path.exists(p_output)


### PR DESCRIPTION
In-memory `fastmultigather` currently only creates output files (`*.gather.csv`, `*.prefetch.csv` if matches are found. Here, we add an option `--create-empty-results` (already a standard `sourmash gather` option; added in https://github.com/sourmash-bio/sourmash/pull/2557 ) to touch the empty files. This is primarily useful for snakemake workflows, we often need all output files to be created for use in downstream steps.

Note: **this only creates empty files if we would expect results (i.e. matching sketch parameters but just no overlapping hashes).** We could also create empty files for sketches without matching params, but that was unnecessary for my application and seemed excessive to me. Happy to add if there's a good reason.

When running `sourmash tax` on empty gather files, we can use `--force` to continue past these files. If using just one gather file, `tax` will not produce empty results. However, we can then `touch` tax output files within the snakemake rule to avoid workflow issues.

