### PR TITLE
MRG: add .PHONY targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all install test wheel sdist upload_dist
+
 PYTHON ?= python
 
 all:


### PR DESCRIPTION
This prevents `make` from recognizing directories as satisfying the target.