### PR TITLE
MRG: fix performance regression in `manysearch` by removing unnecessary downsampling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 /// Python interface Rust code for sourmash_plugin_branchwater.
 use pyo3::prelude::*;
-use singlesketch::singlesketch;
 
 #[macro_use]
 extern crate simple_error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ fn do_manysearch(
     scaled: usize,
     moltype: String,
     output_path: Option<String>,
-    ignore_abundance: Option<bool>
+    ignore_abundance: Option<bool>,
 ) -> anyhow::Result<u8> {
     let againstfile_path: PathBuf = siglist_path.clone().into();
     let selection = build_selection(ksize, scaled, &moltype);

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -73,7 +73,7 @@ pub fn manysearch(
                     if let Some(against_mh) = against_sig.minhash() {
                         for query in query_sketchlist.iter() {
                             // avoid calculating details unless there is overlap
-                            let overlap = query.minhash.count_common(against_mh, false).expect("incompatible sketches") as f64;
+                            let overlap = query.minhash.count_common(against_mh, true).expect("incompatible sketches") as f64;
 
                             // only calculate results if we have shared hashes
                             if overlap > 0.0 {
@@ -104,6 +104,7 @@ pub fn manysearch(
                                     let max_containment_ani = Some(f64::max(qani, mani));
 
                                     let (total_weighted_hashes, n_weighted_found, average_abund, median_abund, std_abund) = if calc_abund_stats {
+                                        panic!("should not be reached.");
                                         match query.minhash.inflated_abundances(&against_mh_ds) {
                                             Ok((abunds, sum_weighted_overlap)) => {
                                                 let sum_all_abunds = against_mh_ds.sum_abunds() as usize;

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -72,15 +72,14 @@ pub fn manysearch(
                 Ok(against_sig) => {
                     if let Some(against_mh) = against_sig.minhash() {
                         for query in query_sketchlist.iter() {
-                            // to do - let user choose?
-                            let calc_abund_stats = against_mh.track_abundance() && !ignore_abundance;
-
-                            let against_mh_ds = against_mh.downsample_scaled(query.minhash.scaled()).unwrap();
-                            let overlap =
-                                query.minhash.count_common(&against_mh_ds, false).unwrap() as f64;
+                            // avoid calculating details unless there is overlap
+                            let overlap = query.minhash.count_common(against_mh, false).expect("incompatible sketches") as f64;
 
                             // only calculate results if we have shared hashes
                             if overlap > 0.0 {
+                                let calc_abund_stats = against_mh.track_abundance() && !ignore_abundance;
+
+                                let against_mh_ds = against_mh.downsample_scaled(query.minhash.scaled()).expect("cannot downsample sketch");
                                 let query_size = query.minhash.size() as f64;
                                 let containment_query_in_target = overlap / query_size;
                                 if containment_query_in_target > threshold {

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -75,7 +75,6 @@ pub fn manysearch(
                             // avoid calculating details unless there is overlap
                             let overlap = query.minhash.count_common(against_mh, true).expect("incompatible sketches") as f64;
 
-                            let calc_abund_stats = against_mh.track_abundance() && !ignore_abundance;
                             let query_size = query.minhash.size() as f64;
                             let containment_query_in_target = overlap / query_size;
                             // only calculate results if we have shared hashes
@@ -100,6 +99,7 @@ pub fn manysearch(
                                 let average_containment_ani = Some((qani + mani) / 2.);
                                 let max_containment_ani = Some(f64::max(qani, mani));
 
+                                let calc_abund_stats = against_mh.track_abundance() && !ignore_abundance;
                                 let (total_weighted_hashes, n_weighted_found, average_abund, median_abund, std_abund) = if calc_abund_stats {
                                     let against_mh_ds = against_mh.downsample_scaled(query.minhash.scaled()).expect("cannot downsample sketch");
 

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -79,7 +79,6 @@ pub fn manysearch(
                             if overlap > 0.0 {
                                 let calc_abund_stats = against_mh.track_abundance() && !ignore_abundance;
 
-                                let against_mh_ds = against_mh.downsample_scaled(query.minhash.scaled()).expect("cannot downsample sketch");
                                 let query_size = query.minhash.size() as f64;
                                 let containment_query_in_target = overlap / query_size;
                                 if containment_query_in_target > threshold {
@@ -105,6 +104,8 @@ pub fn manysearch(
 
                                     let (total_weighted_hashes, n_weighted_found, average_abund, median_abund, std_abund) = if calc_abund_stats {
                                         panic!("should not be reached.");
+                                        let against_mh_ds = against_mh.downsample_scaled(query.minhash.scaled()).expect("cannot downsample sketch");
+
                                         match query.minhash.inflated_abundances(&against_mh_ds) {
                                             Ok((abunds, sum_weighted_overlap)) => {
                                                 let sum_all_abunds = against_mh_ds.sum_abunds() as usize;

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -21,6 +21,7 @@ pub fn manysearch(
     threshold: f64,
     output: Option<String>,
     allow_failed_sigpaths: bool,
+    ignore_abundance: bool,
 ) -> Result<()> {
     // Load query collection
     let query_collection = load_collection(
@@ -72,7 +73,7 @@ pub fn manysearch(
                     if let Some(against_mh) = against_sig.minhash() {
                         for query in query_sketchlist.iter() {
                             // to do - let user choose?
-                            let calc_abund_stats = against_mh.track_abundance();
+                            let calc_abund_stats = against_mh.track_abundance() && !ignore_abundance;
 
                             let against_mh_ds = against_mh.downsample_scaled(query.minhash.scaled()).unwrap();
                             let overlap =

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -105,10 +105,6 @@ pub fn manysearch(
                                 let calc_abund_stats = against_mh.track_abundance() && !ignore_abundance;
                                 let (total_weighted_hashes, n_weighted_found, average_abund, median_abund, std_abund) = if calc_abund_stats {
                                     downsample_and_inflate_abundances(&query.minhash, against_mh).ok()?
-//                                        Err(e) => {
-//                                            eprintln!("Error calculating abundances for query: {}, against: {}; Error: {}", query.name, against_sig.name(), e);
-//                                            continue;
-//                                        }
                                 } else {
                                     (None, None, None, None, None)
                                 };

--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -65,6 +65,8 @@ class Branchwater_Manysearch(CommandLinePlugin):
         p.add_argument('-N', '--no-pretty-print', action='store_false',
                        dest='pretty_print',
                        help="do not display results (e.g. for large output)")
+        p.add_argument('--ignore-abundance', action='store_true',
+                       help="do not do expensive abundance calculations")
 
     def main(self, args):
         print_version()
@@ -80,7 +82,8 @@ class Branchwater_Manysearch(CommandLinePlugin):
                                                            args.ksize,
                                                            args.scaled,
                                                            args.moltype,
-                                                           args.output)
+                                                           args.output,
+                                                           args.ignore_abundance)
         if status == 0:
             notify(f"...manysearch is done! results in '{args.output}'")
 


### PR DESCRIPTION
Tackles https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/463

This PR adjusts `manysearch` so that downsampling is only done on sketches when actually needed. Prior to this, the `downsample_max_hash/downsample_scaled` code was running on sketches even when there was no need.

This PR also adds `--ignore-abundance` to `manysearch` which optionally turns off potentially expensive abundance estimation (which in practice is not that expensive, apparently; see #463).

Fixes https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/466