### PR TITLE
EXP: support running flamegraph code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ tempfile = "3.13.0"
 #target-cpu=native
 #lto = "thin"
 opt-level = 3
+debug = true

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
     - pandas
     - compilers
     - clang
+    - python=3.13


### PR DESCRIPTION
add debug symbols, force specific python version for wheel building.
