### PR TITLE
MRG: rename internal file & functions to use 'rocksdb'

### DIFF
--- a/src/fastmultigather_rocksdb.rs
+++ b/src/fastmultigather_rocksdb.rs
@@ -1,4 +1,4 @@
-/// mastiff_manygather: mastiff-indexed version of fastmultigather.
+/// fastmultigather_rocksdb: rocksdb-indexed version of fastmultigather.
 use anyhow::Result;
 use camino::Utf8PathBuf as PathBuf;
 use rayon::prelude::*;
@@ -12,7 +12,7 @@ use crate::utils::{
     csvwriter_thread, is_revindex_database, load_collection, BranchwaterGatherResult, ReportType,
 };
 
-pub fn mastiff_manygather(
+pub fn fastmultigather_rocksdb(
     queries_file: String,
     index: PathBuf,
     selection: Selection,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ mod fastmultigather;
 mod index;
 mod manysearch;
 mod manysketch;
-mod mastiff_manygather;
-mod mastiff_manysearch;
+mod fastmultigather_rocksdb;
+mod manysearch_rocksdb;
 mod multisearch;
 mod pairwise;
 mod singlesketch;
@@ -45,10 +45,10 @@ fn do_manysearch(
 
     let ignore_abundance = ignore_abundance.unwrap_or(false);
 
-    // if siglist_path is revindex, run mastiff_manysearch; otherwise run manysearch
+    // if siglist_path is revindex, run rocksdb manysearch; otherwise run manysearch
     if is_revindex_database(&againstfile_path) {
-        // note: mastiff_manysearch ignores abundance automatically.
-        match mastiff_manysearch::mastiff_manysearch(
+        // note: manysearch_rocksdb ignores abundance automatically.
+        match manysearch_rocksdb::manysearch_rocksdb(
             querylist_path,
             againstfile_path,
             selection,
@@ -133,9 +133,9 @@ fn do_fastmultigather(
     let selection = build_selection(ksize, scaled, &moltype);
     let allow_failed_sigpaths = true;
 
-    // if a siglist path is a revindex, run mastiff_manygather. If not, run multigather
+    // if a siglist path is a revindex, run rocksdb fastmultigather. If not, run multigather
     if is_revindex_database(&againstfile_path) {
-        match mastiff_manygather::mastiff_manygather(
+        match fastmultigather_rocksdb::fastmultigather_rocksdb(
             query_filenames,
             againstfile_path,
             selection.clone(),

--- a/src/manysearch_rocksdb.rs
+++ b/src/manysearch_rocksdb.rs
@@ -1,4 +1,4 @@
-/// mastiff_manysearch: mastiff-indexed version of manysearch.
+/// manysearch_rocksdb: rocksdb-indexed version of manysearch.
 use anyhow::Result;
 use camino::Utf8PathBuf as PathBuf;
 use log::debug;
@@ -15,7 +15,7 @@ use crate::utils::{
     csvwriter_thread, is_revindex_database, load_collection, ReportType, SearchResult,
 };
 
-pub fn mastiff_manysearch(
+pub fn manysearch_rocksdb(
     queries_path: String,
     index: PathBuf,
     selection: Selection,


### PR DESCRIPTION
Rename `mastiff_manygather` to `fastmultigather_rocksdb` and `mastiff_manysearch` to `manysearch_rocksdb`.
