### PR TITLE
MRG: bump to version 0.9.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "sourmash_plugin_branchwater"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash_plugin_branchwater"
-version = "0.9.11"
+version = "0.9.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What's Changed

Changes and additions:
* MRG: switch to `importlib.metadata` from `pkg_resources` (into main) by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/547
* MRG: add `--output-all-comparisons` to manysearch, multisearch, and pairwise by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/544* MRG: update to (prospective) sourmash r0.18.0 by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/548
* MRG: add capacity for skipmer sketching and search by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/531
* MRG: integrate sketching utils from directsketch by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/516

Updates:
* Bump pyo3 from 0.22.6 to 0.23.1 by @dependabot in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/530
* Bump serde from 1.0.214 to 1.0.215 by @dependabot in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/528
* Bump serde_json from 1.0.132 to 1.0.133 by @dependabot in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/529
* Bump pyo3 from 0.23.1 to 0.23.2 by @dependabot in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/537
* Bump anyhow from 1.0.93 to 1.0.94 by @dependabot in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/541
* Bump serde from 1.0.215 to 1.0.216 by @dependabot in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/545
* Bump pyo3 from 0.23.2 to 0.23.3 by @dependabot in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/540



**Full Changelog**: https://github.com/sourmash-bio/sourmash_plugin_branchwater/compare/v0.9.11...v0.9.12