### PR TITLE
MRG: test generated manifest 

### DIFF
--- a/src/utils/buildutils.rs
+++ b/src/utils/buildutils.rs
@@ -889,7 +889,9 @@ impl BuildCollection {
                 record.set_filename(Some(filename.clone()));
                 record.set_md5(Some(sig.md5sum()));
                 record.set_md5short(Some(sig.md5sum()[0..8].into()));
-                record.set_n_hashes(Some(sig.minhash().map(|mh| mh.size()).unwrap_or(0)));
+                record.set_n_hashes(Some(
+                    sig.get_sketch().expect("cannot retrieve sketch").size(),
+                ));
 
                 // note, this needs to be set when writing sigs (not here)
                 // record.set_internal_location("")


### PR DESCRIPTION
It turns out the manifest test were re-building the manifest from the sigs, and not testing the manifest in the zip file. This PR rectifies that and fixes the code for `n_hashes`.