### PR TITLE
MRG: bump plugin version to v0.9.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "sourmash_plugin_branchwater"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash_plugin_branchwater"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - sourmash>=4.8.13,<5
+    - sourmash-minimal>=4.8.14,<5
     - pip
     - rust
     - maturin>=1,<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "sourmash_plugin_branchwater"
 description = "fast command-line extensions for sourmash"
 readme = "README.md"
-version = "0.9.12"
+version = "0.9.13"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     ]
-dependencies = ["sourmash>=4.8.13,<5"]
+dependencies = ["sourmash>=4.8.14,<5"]
 
 authors = [
   { name="N. Tessa Pierce-Ward", orcid="0000-0002-2942-5331" },
@@ -60,7 +60,7 @@ libclang = ">=16.0.6,<16.1"
 python = "3.10.*"
 rust = ">=1.80.0,<1.81"
 maturin = ">=1.7.4,<2"
-sourmash-minimal = ">=4.8.10,<5"
+sourmash-minimal = ">=4.8.14,<5"
 
 [tool.pixi.feature.build.target.linux-64.dependencies]
 patchelf = ">=0.17.2,<0.18"


### PR DESCRIPTION
NOTE: have to wait for sourmash v4.8.13 conda-forge & bioconda packages to build before release.