### PR TITLE
Documentation update: `manysketch --force` allows use of FASTA files in more than one sketch

### DIFF
--- a/src/python/sourmash_plugin_branchwater/__init__.py
+++ b/src/python/sourmash_plugin_branchwater/__init__.py
@@ -732,7 +732,7 @@ class Branchwater_Manysketch(CommandLinePlugin):
             "-f",
             "--force",
             action="store_true",
-            help="allow use of individual FASTA files in more than more sketch",
+            help="allow use of individual FASTA files in more than one sketch",
         )
 
     def main(self, args):


### PR DESCRIPTION
Updated documentation to reference the behavior of `--force` in do_manysketch to indicate this option allows "use of individual FASTA files in more than  _one_ sketch"