### PR TITLE
MRG: remove ORCID from authors table in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ classifiers = [
 dependencies = ["sourmash>=4.8.14,<5"]
 
 authors = [
-  { name="N. Tessa Pierce-Ward", orcid="0000-0002-2942-5331" },
-  { name="Luiz Irber", orcid="0000-0003-4371-9659" },
-  { name="Mohamed Abuelanin", orcid="0000-0002-3419-4785" },
-  { name="Olga Botvinnik", orcid="0000-0003-4412-7970" },
-  { name="C. Titus Brown", orcid="0000-0001-6001-2677" },
+  { name="N. Tessa Pierce-Ward" },
+  { name="Luiz Irber" },
+  { name="Mohamed Abuelanin" },
+  { name="Olga Botvinnik" },
+  { name="C. Titus Brown" },
 ]
 
 [build-system]


### PR DESCRIPTION
Latest version of maturin (1.8.2) breaks on ORCID in pyproject.toml - 
```
� maturin failed
  Caused by: pyproject.toml at /Users/t/dev/sourmash_plugin_branchwater/pyprojec
t.toml is invalid
  Caused by: TOML parse error at line 14, column 11
   |
14 | authors = [
   |           ^
a table with 'name' and/or 'email' keys
```
This PR removes orcid.