### PR TITLE
MRG: report % of target matched by query

### DIFF
--- a/src/manysearch_rocksdb.rs
+++ b/src/manysearch_rocksdb.rs
@@ -178,6 +178,8 @@ pub(crate) fn manysearch_rocksdb_obj(
                                     max_containment_ani: None,
                                     n_weighted_found: None,
                                     total_weighted_hashes: None,
+                                    containment_target_in_query: None,
+                                    f_weighted_target_in_query: None,
                                 });
                             }
                         }

--- a/src/python/tests/test_manysearch.py
+++ b/src/python/tests/test_manysearch.py
@@ -283,6 +283,8 @@ def test_simple_abund(runtmp):
     std_abund = round(float(row["std_abund"]), 4)
     n_weighted_found = int(row["n_weighted_found"])
     total_weighted_hashes = int(row["total_weighted_hashes"])
+    containment_target_in_query = float(row["containment_target_in_query"])
+    f_weighted_target_in_query = float(row["f_weighted_target_in_query"])
 
     assert query_name == "NC_009661.1"
     assert average_abund == round(11.365853658536600, 4)
@@ -290,6 +292,8 @@ def test_simple_abund(runtmp):
     assert std_abund == round(4.976805212676670, 4)
     assert n_weighted_found == 466
     assert total_weighted_hashes == 73489
+    assert round(containment_target_in_query, 4) == round(0.0097619047619047, 4)
+    assert round(f_weighted_target_in_query, 4) == round(0.0063002626243383, 4)
 
     row = dd[2]
     query_name = row["query_name"].split()[0]
@@ -298,6 +302,8 @@ def test_simple_abund(runtmp):
     std_abund = round(float(row["std_abund"]), 4)
     n_weighted_found = int(row["n_weighted_found"])
     total_weighted_hashes = int(row["total_weighted_hashes"])
+    containment_target_in_query = float(row["containment_target_in_query"])
+    f_weighted_target_in_query = float(row["f_weighted_target_in_query"])
 
     assert query_name == "NC_011665.1"
     assert average_abund == round(10.386363636363600, 4)
@@ -305,6 +311,8 @@ def test_simple_abund(runtmp):
     assert std_abund == round(6.932190750047300, 4)
     assert n_weighted_found == 457
     assert total_weighted_hashes == 73489
+    assert round(containment_target_in_query, 4) == round(0.0104761904761904, 4)
+    assert round(f_weighted_target_in_query, 4) == round(0.0062186177523166, 4)
 
 
 def test_simple_indexed(runtmp, zip_query, indexed_query):

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1024,6 +1024,11 @@ pub struct ManySearchResult {
     pub n_weighted_found: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_weighted_hashes: Option<u64>,
+    // to do: don't need this to be option if can also add it in rocksdb search version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containment_target_in_query: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub f_weighted_target_in_query: Option<f64>,
 }
 
 pub struct InterimGatherResult {


### PR DESCRIPTION
For a project, we'd like to know the fraction of each metagenome matched by the query. 

I propose adding two columns to `manysearch` results:
- `containment_target_in_query` -  the % of the unique metagenome content matching the query
- `f_weighted_target_in_query` - the % of weighted metagenome content matching the query

We were already calculating the first, just not reporting it. Getting the second (`f_weighted_target_in_query`) is straightforward if we're already calculating the abundance stats, I think: `abundance-weighted sum of intersected hashes` / `abundance-weighted sum of all metagenome hashes`. 

`manysearch` doesn't have a single number for the reverse abundance stat: instead we have `avg_abund`, `med_abund`, `std_abund` for the query. But that's because we're dividing by the number of intersected hashes to get an abundance estimate for the query, rather than finding the total % of all metagenome hashes, as in this case.