### PR TITLE
Update zip to 3.0.0 because 2.5.0 doesn't exist on crates.io anymore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,13 +2373,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "indexmap",
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.27"
 env_logger = { version = "0.11.6" }
 simple-error = "0.3.1"
 anyhow = "1.0.98"
-zip = { version = "2.5", default-features = false }
+zip = { version = "3.0.0", default-features = false }
 tempfile = "3.20"
 needletail = "0.6.3"
 csv = "1.3.1"


### PR DESCRIPTION
Hello, I was getting errors with using this repo as a dependency in https://github.com/seanome/kmerseek/pull/20

Specifically, the 2.5.0 version of `zip` seems to not be available anymore:

```zsh
(base)
 ✘  Fri  6 Jun - 15:40  ~/code/sourmash_plugin_branchwater   origin ☊ main 2☀ 2● 
  cargo build
    Updating crates.io index
error: failed to select a version for the requirement `zip = "^2.5"`
candidate versions found which didn't match: 4.0.0, 3.0.0, 2.4.2, ...
location searched: crates.io index
required by package `sourmash_plugin_branchwater v0.9.14-dev (/Users/olga/code/sourmash_plugin_branchwater)`
if you are looking for the prerelease package it needs to be specified explicitly
    zip = { version = "0.10.0-alpha.1" }
perhaps a crate was updated and forgotten to be re-vendored?
```

Turns out the v2.5.0 version of [zip](https://crates.io/crates/zip/versions) was removed from crates.io:

![image](https://github.com/user-attachments/assets/45df60d5-3c09-4efb-a460-67c40619738d)

This PR bumps the version to 3.0.0. I'm still fixing my environment to check if the tests work.
