### PR TITLE
upd rust to 1.75 for zip compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,13 +2373,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "153a6fff49d264c4babdcfa6b4d534747f520e56e8f0f384f3b808c4b64cc1fd"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "indexmap",
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sourmash_plugin_branchwater"
 version = "0.9.14-dev"
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.75.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -20,7 +20,7 @@ log = "0.4.27"
 env_logger = { version = "0.11.6" }
 simple-error = "0.3.1"
 anyhow = "1.0.98"
-zip = { version = "2.5", default-features = false }
+zip = { version = "4.0", default-features = false }
 tempfile = "3.20"
 needletail = "0.6.3"
 csv = "1.3.1"

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
     - sourmash-minimal>=4.8.14,<5
     - pip
-    - rust
+    - rust=1.75
     - maturin>=1,<2
     - pytest
     - pandas


### PR DESCRIPTION
- update rust to 1.75 in `Cargo.toml`
- also pin rust to  1.75 in `environment.yml` to make sure we're installing the pinned rust version for tests.

Actually, we were already installing 1.75 here! So we were on 1.75 for tests already: https://github.com/sourmash-bio/sourmash_plugin_branchwater/blob/main/.github/workflows/build-test.yml#L47C11-L47C38

This puts us out of sync with base sourmash (1.74), but it doesn't seem to present an issue here.

@ctb thoughts on pinning version in `environment.yml` vs in the `build-test.yml` workflow (or keeping both)?