### PR TITLE
Pub mod search_significance and utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,13 +2373,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "153a6fff49d264c4babdcfa6b4d534747f520e56e8f0f384f3b808c4b64cc1fd"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "indexmap",
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sourmash_plugin_branchwater"
 version = "0.9.14-dev"
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.75.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -20,7 +20,7 @@ log = "0.4.27"
 env_logger = { version = "0.11.6" }
 simple-error = "0.3.1"
 anyhow = "1.0.98"
-zip = { version = "2.5", default-features = false }
+zip = { version = "4.0", default-features = false }
 tempfile = "3.20"
 needletail = "0.6.3"
 csv = "1.3.1"

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
     - sourmash-minimal>=4.8.14,<5
     - pip
-    - rust
+    - rust=1.75
     - maturin>=1,<2
     - pytest
     - pandas

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 #[macro_use]
 extern crate simple_error;
 
-mod utils;
+pub mod utils;
 use crate::utils::build_selection;
 use crate::utils::is_revindex_database;
 mod check;
@@ -22,7 +22,7 @@ mod manysearch_rocksdb;
 mod manysketch;
 mod multisearch;
 mod pairwise;
-mod search_significance;
+pub mod search_significance;
 mod singlesketch;
 
 use camino::Utf8PathBuf as PathBuf;


### PR DESCRIPTION
PR to https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/654

I'm using the `search_significance` and `utils` in this PR: https://github.com/seanome/kmerseek/pull/20, and would like to make them public so I may use them. 

Here's the import in this file: https://github.com/seanome/kmerseek/pull/20/files#diff-b3fb330e580c399abaefc545aa8df06784ce7a0e81797cc1f1ad5d769e3180f6

```rust
use sourmash_plugin_branchwater::search_significance::{
    compute_inverse_document_frequency, get_hash_frequencies, Normalization,
};
use sourmash_plugin_branchwater::utils::multicollection::SmallSignature;
```


- **upd rust to 1.75 for zip compatibility**
- **Make uitils and search_significance modules public**


Thank you!