### PR TITLE
WIP: remove dependabot ignore for zip; update to 4.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
   allow:
     - dependency-type: "direct"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "zip"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.27"
 env_logger = { version = "0.11.6" }
 simple-error = "0.3.1"
 anyhow = "1.0.98"
-zip = { version = "4.0", default-features = false }
+zip = { version = "4.2.0", default-features = false }
 tempfile = "3.20"
 needletail = "0.6.3"
 csv = "1.3.1"


### PR DESCRIPTION
We no longer need to ignore updates for zip crate (#389). Let's remove dependabot ignore and then go ahead and update.