### PR TITLE
MRG: bump version to 0.9.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,14 @@
 name = "sourmash_plugin_branchwater"
 description = "fast command-line extensions for sourmash"
 readme = "README.md"
-version = "0.9.14-dev"
-requires-python = ">=3.10"
+version = "0.9.14"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     ]
-dependencies = ["sourmash>=4.8.14,<5"]
+dependencies = ["sourmash>=4.9.4,<5"]
 
 authors = [
   { name="N. Tessa Pierce-Ward" },


### PR DESCRIPTION
## release notes branchwater plugin v0.9.14

## What's Changed

* Documentation update: `manysketch --force` allows use of FASTA files in more than one sketch by @mlovci in https://github.com/sourmash-bio/
* MRG: update RocksDB docs with a reference to sourmash v4.9.0 compat by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/658
* MRG: more docs updates: skip-mers and scaled. by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/663
* MRG: fix match filtering in manysearch_rocksdb by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/661
* MRG: report % of target matched by query by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/641
* Pub mod search_significance and utils by @olgabot in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/657
* MRG: add average_containment and cosine sim to pairwise and multisearch by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/646

### Developer updates

* MRG: bump version to 0.9.14-dev by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/593
* MRG: fix `pyproject.toml` version to 0.9.14-dev by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/594
* MRG: remove ORCID from authors table in pyproject.toml by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/603
* MRG: fix `black` formatting by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/618
* MRG: update zip version to 2.5 by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/635
* MRG: pin rust version to match sourmash by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/636
* MRG: update for sourmash r0.20.0 by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/627
* upd rust to 1.75 for zip compatibility by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/654
* MRG: remove dependabot ignore for zip; update to 4.2 by @bluegenes in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/668
* MRG: bump version to 0.9.14 by @ctb in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/703

### Automated updates



* Bump getset from 0.1.3 to 0.1.4 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/596
* Bump serde_json from 1.0.135 to 1.0.137 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/595
* Bump log from 0.4.22 to 0.4.25 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/597
* Bump rustworkx-core from 0.15.1 to 0.16.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/598
* Bump tempfile from 3.15.0 to 3.16.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/600
* Bump serde_json from 1.0.137 to 1.0.138 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/599
sourmash_plugin_branchwater/pull/601
* Bump tempfile from 3.16.0 to 3.17.1 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/605
* Bump anyhow from 1.0.95 to 1.0.96 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/612
* Bump serde from 1.0.217 to 1.0.218 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/611
* Bump serde_json from 1.0.138 to 1.0.139 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/610
* Bump log from 0.4.25 to 0.4.26 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/609
* Bump log from 0.4.26 to 0.4.27 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/623
* Bump tempfile from 3.17.1 to 3.19.1 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/626
* Bump serde from 1.0.218 to 1.0.219 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/621
* Bump rust_decimal from 1.36.0 to 1.37.1 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/625
* Bump pyo3 from 0.23.4 to 0.24.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/619
* Bump rust_decimal_macros from 1.36.0 to 1.37.1 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/624
* Bump getset from 0.1.4 to 0.1.5 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/614
* Bump serde_json from 1.0.139 to 1.0.140 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/616
* Bump anyhow from 1.0.96 to 1.0.97 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/615
* Bump pyo3 from 0.24.1 to 0.24.2 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/643
* Bump assert_cmd from 2.0.16 to 2.0.17 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/639
* Bump anyhow from 1.0.97 to 1.0.98 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/638
* Bump tempfile from 3.19.1 to 3.20.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/648
* Bump niffler from 2.7.0 to 3.0.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/649
* Bump pyo3 from 0.24.2 to 0.25.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/650
* Bump camino from 1.1.9 to 1.1.10 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/656
* Update pytest requirement from <8.4.0,>=6.2.4 to >=6.2.4,<8.5.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/655
* Bump rust_decimal from 1.37.1 to 1.37.2 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/660
* Bump pyo3 from 0.25.0 to 0.25.1 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/659
* Bump getset from 0.1.5 to 0.1.6 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/667
* Bump env_logger from 0.11.6 to 0.11.8 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/670
* Bump sourmash from 0.20.0 to 0.21.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/669
* Bump serde_json from 1.0.140 to 1.0.141 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/674
* Bump actions/checkout from 4 to 5 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/676
* Bump serde_json from 1.0.141 to 1.0.142 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/675
* Bump camino from 1.1.10 to 1.1.11 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/677
* Bump glob from 0.3.2 to 0.3.3 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/678
* Bump serde_json from 1.0.142 to 1.0.143 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/686
* Bump tempfile from 3.20.0 to 3.21.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/687
* Bump pyo3 from 0.25.1 to 0.26.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/691
* Bump camino from 1.1.11 to 1.1.12 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/690
* Bump anyhow from 1.0.98 to 1.0.99 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/682
* Bump log from 0.4.27 to 0.4.28 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/693
* Bump rust_decimal_macros from 1.37.1 to 1.38.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/701
* Bump serde from 1.0.219 to 1.0.224 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/700
* Bump rust_decimal from 1.37.2 to 1.38.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/696
* Bump tempfile from 3.21.0 to 3.22.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/697
* Bump serde_json from 1.0.143 to 1.0.145 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/698
* Bump camino from 1.1.12 to 1.2.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/699
* Update pytest-cov requirement from <7.0,>=2.12 to >=2.12,<8.0 by @dependabot[bot] in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/694


## New Contributors
* @mlovci made their first contribution in https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/601

**Full Changelog**: https://github.com/sourmash-bio/sourmash_plugin_branchwater/compare/v0.9.13...v0.9.14